### PR TITLE
Run TCK with server side selectors

### DIFF
--- a/.github/workflows/tck-client-side-filters.yaml
+++ b/.github/workflows/tck-client-side-filters.yaml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Run TCK with Client Side Filters
 
 on:
   push:
@@ -27,8 +27,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build and test
-        run: mvn -B clean verify
+        run: mvn -B clean intall -DskipTests -Dspotbugs.skip=true
 
-      - name: TCK tests
-        run: mvn -B verify -Prun-tck
-
+      - name: TCK tests - client side filters
+        run: mvn -B verify -DskipTests -Prun-tck

--- a/.github/workflows/tck-client-side-filters.yaml
+++ b/.github/workflows/tck-client-side-filters.yaml
@@ -26,8 +26,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build and test
-        run: mvn -B clean intall -DskipTests -Dspotbugs.skip=true
+      - name: Build
+        run: mvn -B clean install -DskipTests -Dspotbugs.skip=true
 
       - name: TCK tests - client side filters
         run: mvn -B verify -DskipTests -Prun-tck

--- a/.github/workflows/tck-server-side-filters.yaml
+++ b/.github/workflows/tck-server-side-filters.yaml
@@ -26,8 +26,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build and test
-        run: mvn -B clean intall -DskipTests -Dspotbugs.skip=true
+      - name: Build
+        run: mvn -B clean install -DskipTests -Dspotbugs.skip=true
 
       - name: TCK tests - server side filters
         run: mvn -B verify -DskipTests -Prun-tck-server-side-filters

--- a/.github/workflows/tck-server-side-filters.yaml
+++ b/.github/workflows/tck-server-side-filters.yaml
@@ -1,0 +1,33 @@
+name: Run TCK with Server Side Filters
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build and test
+        run: mvn -B clean intall -DskipTests -Dspotbugs.skip=true
+
+      - name: TCK tests - server side filters
+        run: mvn -B verify -DskipTests -Prun-tck-server-side-filters

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,31 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build and test
+        run: mvn -B clean verify
+

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -38,8 +38,7 @@ public class DockerTest {
   private static final String TEST_PULSAR_DOCKER_IMAGE_NAME =
       System.getProperty("testPulsarDockerImageName");
 
-  @TempDir
-  Path tempDir;
+  @TempDir Path tempDir;
 
   @Test
   public void testPulsar272() throws Exception {

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/PulsarContainer.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/PulsarContainer.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 

--- a/tck-executor/pom.xml
+++ b/tck-executor/pom.xml
@@ -44,6 +44,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
@@ -102,6 +109,35 @@
             </executions>
             <configuration>
               <executable>${basedir}/run_from_maven.sh</executable>
+              <arguments>
+                <argument>ts.jte</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>run-tck-server-side-filters</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <executable>${basedir}/run_from_maven.sh</executable>
+              <arguments>
+                <argument>ts.serverSideFilters.jte</argument>
+              </arguments>
             </configuration>
           </plugin>
         </plugins>

--- a/tck-executor/run_from_maven.sh
+++ b/tck-executor/run_from_maven.sh
@@ -4,12 +4,17 @@ set -x
 HERE=$(dirname $0)
 HERE=$(realpath "$HERE")
 
+CONFIGURATION_FILE=${1:-ts.jte}
+echo "CONFIGURATION_FILE is $CONFIGURATION_FILE"
+
 unzip -o $HERE/jakarta-messaging-tck-2.0.0.zip -d $HERE/target
 
 TS_HOME=target/messaging-tck
 
 VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
 cp ts.* $TS_HOME/bin
+# overwrite ts.jte
+cp $CONFIGURATION_FILE $TS_HOME/bin/ts.jte
 echo "jms.home=$HERE" >> $TS_HOME/bin/ts.jte
 echo "jms.classes=\${jms.home}/target/tck-executor-$VERSION.jar" >> $TS_HOME/bin/ts.jte
 
@@ -26,6 +31,7 @@ wget -O - http://localhost:8080/lookup/v2/topic/persistent/pulsar/system/transac
 
 # move to the directory that contains the test you want to run
 cd $TS_HOME/src/com/sun/ts/tests
+
 
 ant runclient
 ANTEXITCODE=$?

--- a/tck-executor/src/main/java/com/datastax/oss/pulsar/jms/tests/JNDIInitialContextFactory.java
+++ b/tck-executor/src/main/java/com/datastax/oss/pulsar/jms/tests/JNDIInitialContextFactory.java
@@ -92,6 +92,16 @@ public class JNDIInitialContextFactory implements InitialContextFactory {
       // com.sun.ts.tests.jms.core20.jmscontexttopictests.Client.verifyClientIDOnAdminConfiguredIDTest
       configuration.put("jms.clientId", "cts");
     }
+
+    System.getProperties()
+        .forEach(
+            (k, v) -> {
+              if (k.toString().startsWith("JMS_TCK_CLIENT_")) {
+                String key = k.toString().substring("JMS_TCK_CLIENT_".length()).replace("_", ".");
+                System.out.println("Found property " + k + ". Adding " + key + " = " + v);
+                configuration.put(key, v);
+              }
+            });
     return new PulsarConnectionFactory(configuration);
   }
 

--- a/tck-executor/start_pulsar.sh
+++ b/tck-executor/start_pulsar.sh
@@ -8,7 +8,7 @@ HERE=$(dirname $0)
 HERE=$(realpath "$HERE")
 FILTERSDIRECTORY=$HERE/../pulsar-jms-filters/target
 docker rm -f pulsar-jms-runner
-docker run --name pulsar-jms-runner -v $FILTERSDIRECTORY:/pulsar/filters -v $HERE/conf:/pulsar/conf -d -p 8080:8080 -p 6650:6650 $IMAGENAME /pulsar/bin/pulsar standalone
+docker run --name pulsar-jms-runner -v $FILTERSDIRECTORY:/pulsar/filters -v $HERE/conf:/pulsar/conf -d -p 8080:8080 -p 6650:6650 $IMAGENAME /pulsar/bin/pulsar standalone -nss -nfw
 # Wait for pulsar to start
 echo "Waiting 15 seconds"
 

--- a/tck-executor/ts.serverSideFilters.jte
+++ b/tck-executor/ts.serverSideFilters.jte
@@ -170,6 +170,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
 		-Djava.security.policy="${bin.dir}/harness.policy" \
 		-Djava.security.manager \
 		-Dlog4j2.debug=true \
+                -DJMS_TCK_CLIENT_jms_useServerSideSelectors=true \
 		-Dorg.slf4j.simpleLogger.defaultLogLevel=warn \
 		-Djava.naming.factory.initial=${java.naming.factory.initial} \
 		-Ddeliverable.class=${deliverable.class} \


### PR DESCRIPTION
Modifications:
- add support in the JDNC factory to read configuration from system properties
- add support in the TCK runner to use custom configurations
- create new Maven profile to run the TCK with server side filters
- split CI: tests, CI with client side filters, CI with server side filters