### PR TITLE
Support Server-Side Filters for Queues, NoLocal and TimeToLive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- waiting for a Apache Pulsar 2.10.1 release, in the meantime we use DataStax Luna Streaming
          that is a fork of Apache Pulsar  -->
     <pulsar.groupId>com.datastax.oss</pulsar.groupId>
-    <pulsar.version>2.10.0.2-SNAPSHOT</pulsar.version>
+    <pulsar.version>2.10.0.2</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
@@ -499,11 +499,6 @@ limitations under the License.]]></inlineHeader>
       <id>ossrh</id>
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
-    <snapshotRepository>
-      <id>datastax-snapshots-local</id>
-      <name>DataStax Local Snapshots</name>
-      <url>https://repo.sjc.dsinternal.org/artifactory/datastax-snapshots-local/</url>
-    </snapshotRepository>
   </distributionManagement>
   <!-- to use Luna Straaming -->
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,10 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <jms.version>2.0.3</jms.version>
-    <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
-    <pulsar.version>2.10.1-SNAPSHOT</pulsar.version>
+    <!-- waiting for a Apache Pulsar 2.10.1 release, in the meantime we use DataStax Luna Streaming
+         that is a fork of Apache Pulsar  -->
+    <pulsar.groupId>com.datastax.oss</pulsar.groupId>
+    <pulsar.version>2.10.0.1</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
@@ -67,7 +69,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.pulsar</groupId>
+        <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar</artifactId>
         <version>${pulsar.version}</version>
         <type>pom</type>
@@ -503,16 +505,16 @@ limitations under the License.]]></inlineHeader>
       <url>https://repo.sjc.dsinternal.org/artifactory/datastax-snapshots-local/</url>
     </snapshotRepository>
   </distributionManagement>
-  <!-- to use 2.10.1-SNAPSHOT -->
+  <!-- to use Luna Straaming -->
   <repositories>
     <repository>
-      <id>apache-snapshots</id>
-      <url>https://repository.apache.org/snapshots</url>
+      <id>DataStax Public repo</id>
+      <url>https://repo.datastax.com/artifactory/datastax-public-releases-local</url>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </snapshots>
       <releases>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </releases>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- waiting for a Apache Pulsar 2.10.1 release, in the meantime we use DataStax Luna Streaming
          that is a fork of Apache Pulsar  -->
     <pulsar.groupId>com.datastax.oss</pulsar.groupId>
-    <pulsar.version>2.10.0.1</pulsar.version>
+    <pulsar.version>2.10.0.2-SNAPSHOT</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -46,6 +46,17 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-jms-filters</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>${pulsar.groupId}</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client</artifactId>
       <version>${pulsar.version}</version>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -36,22 +36,22 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.pulsar</groupId>
+          <groupId>${pulsar.groupId}</groupId>
           <artifactId>pulsar-client-original</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.pulsar</groupId>
+          <groupId>${pulsar.groupId}</groupId>
           <artifactId>pulsar-client-admin-original</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client</artifactId>
       <version>${pulsar.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client-admin</artifactId>
       <version>${pulsar.version}</version>
     </dependency>

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -56,7 +56,8 @@ public class JMSFilter implements EntryFilter {
     final String jmsSelectorOnSubscription;
     if (subscription instanceof PersistentSubscription) {
       // in 2.10 only PersistentSubscription has getSubscriptionProperties method
-      Map<String, String> subscriptionProperties = ((PersistentSubscription) subscription).getSubscriptionProperties();
+      Map<String, String> subscriptionProperties =
+          ((PersistentSubscription) subscription).getSubscriptionProperties();
       if (subscriptionProperties != null) {
         jmsSelectorOnSubscription = subscriptionProperties.getOrDefault("jms.selector", "");
         jmsFiltering = jmsFiltering || "true".equals(subscriptionProperties.get("jms.filtering"));
@@ -107,16 +108,17 @@ public class JMSFilter implements EntryFilter {
     }
 
     SelectorSupport selectorOnSubscription =
-            selectors.computeIfAbsent(
-                    jmsSelectorOnSubscription,
-                    s -> {
-                      try {
-                        return SelectorSupport.build(s, !jmsSelectorOnSubscription.isEmpty());
-                      } catch (JMSException err) {
-                        log.error("Cannot build subscription selector from '{}'", jmsSelectorOnSubscription, err);
-                        return null;
-                      }
-                    });
+        selectors.computeIfAbsent(
+            jmsSelectorOnSubscription,
+            s -> {
+              try {
+                return SelectorSupport.build(s, !jmsSelectorOnSubscription.isEmpty());
+              } catch (JMSException err) {
+                log.error(
+                    "Cannot build subscription selector from '{}'", jmsSelectorOnSubscription, err);
+                return null;
+              }
+            });
     if (selectorOnSubscription == null && !jmsSelectorOnSubscription.isEmpty()) {
       // error creating the selector. try again later
       return FilterResult.RESCHEDULE;
@@ -200,14 +202,15 @@ public class JMSFilter implements EntryFilter {
               }
 
               if (!jmsSelectorOnSubscription.isEmpty()) {
-                boolean matchesSubscriptionFilter = matches(
-                                typedProperties,
-                                null,
-                                metadata,
-                                topicName,
-                                selectorOnSubscription,
-                                destinationTypeForTheClient,
-                                jmsExpiration);
+                boolean matchesSubscriptionFilter =
+                    matches(
+                        typedProperties,
+                        null,
+                        metadata,
+                        topicName,
+                        selectorOnSubscription,
+                        destinationTypeForTheClient,
+                        jmsExpiration);
                 matches = matches && matchesSubscriptionFilter;
                 if (matchesSubscriptionFilter) {
                   allFilteredBySubscriptionFilter = false;
@@ -228,7 +231,10 @@ public class JMSFilter implements EntryFilter {
           if (oneAccepted) {
             return FilterResult.ACCEPT;
           }
-          log.info("allFilteredBySubscriptionFilter {} ??? {}", allFilteredBySubscriptionFilter, rejectResultForSelector);
+          log.info(
+              "allFilteredBySubscriptionFilter {} ??? {}",
+              allFilteredBySubscriptionFilter,
+              rejectResultForSelector);
           return rejectResultForSelector;
         } finally {
           uncompressedPayload.release();
@@ -250,7 +256,8 @@ public class JMSFilter implements EntryFilter {
         }
 
         if (!jmsSelectorOnSubscription.isEmpty()) {
-          boolean matchesSubscriptionFilter = matches(
+          boolean matchesSubscriptionFilter =
+              matches(
                   typedProperties,
                   null,
                   metadata,

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -70,7 +70,8 @@ public class JMSFilter implements EntryFilter {
     String jmsSelectorRejectAction = consumerMetadata.get("jms.selector.reject.action");
     // noLocal filter
     String filterJMSConnectionID = consumerMetadata.getOrDefault("jms.filter.JMSConnectionID", "");
-    boolean forceDropRejected = "true".equals(consumerMetadata.getOrDefault("jms.force.drop.rejected", "false"));
+    boolean forceDropRejected =
+        "true".equals(consumerMetadata.getOrDefault("jms.force.drop.rejected", "false"));
     final FilterResult rejectResultForSelector;
     if ("drop".equals(jmsSelectorRejectAction)) {
       // this is the common behaviour for a Topics
@@ -132,7 +133,7 @@ public class JMSFilter implements EntryFilter {
               // all the messages in the batch come from the Producer/Connection
               // so we can reject the whole batch immediately at the first entry
               if (!filterJMSConnectionID.isEmpty()
-                      && filterJMSConnectionID.equals(typedProperties.get("JMSConnectionID"))) {
+                  && filterJMSConnectionID.equals(typedProperties.get("JMSConnectionID"))) {
                 if (isExclusive || forceDropRejected) {
                   return FilterResult.REJECT;
                 } else {
@@ -218,8 +219,10 @@ public class JMSFilter implements EntryFilter {
         }
 
         if (matches) {
+          log.info("result {} {} {}", entry.getPosition(), FilterResult.ACCEPT, typedProperties);
           return FilterResult.ACCEPT;
         }
+        log.info("result {} {} {}", entry.getPosition(), rejectResultForSelector, typedProperties);
         return rejectResultForSelector;
       }
 

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -60,24 +60,20 @@ public class JMSFilter implements EntryFilter {
     String jmsSelectorOnConsumer = consumerMetadata.get("jms.selector");
     String jmsSelectorOnSubscription = subscriptionProperties.get("jms.selector");
     String destinationTypeForTheClient = consumerMetadata.get("jms.destination.type");
+    String jmsRejectAction = consumerMetadata.get("jms.reject.action");
     final FilterResult rejectResult;
     final String jmsSelector;
-    final boolean selectorIsOnConsumer;
-    if (jmsSelectorOnConsumer != null) {
-      selectorIsOnConsumer = true;
-      jmsSelector = jmsSelectorOnConsumer;
-      String jmsRejectAction = consumerMetadata.get("jms.reject.action");
-      if ("drop".equals(jmsRejectAction)) {
-        rejectResult = FilterResult.REJECT;
-      } else {
-        // this is the common behaviour for a Queue
-        rejectResult = FilterResult.RESCHEDULE;
-      }
-    } else {
-      // this is the common behaviour for a Topic
-      selectorIsOnConsumer = false;
-      jmsSelector = jmsSelectorOnSubscription;
+    if ("drop".equals(jmsRejectAction)) {
+      // this is the common behaviour for a Topics
       rejectResult = FilterResult.REJECT;
+    } else {
+      // this is the common behaviour for a Queue
+      rejectResult = FilterResult.RESCHEDULE;
+    }
+    if (jmsSelectorOnConsumer != null) {
+      jmsSelector = jmsSelectorOnConsumer;
+    } else {
+      jmsSelector = jmsSelectorOnSubscription;
     }
     if (jmsSelector == null || jmsSelector.isEmpty()) {
       return FilterResult.ACCEPT;
@@ -157,11 +153,7 @@ public class JMSFilter implements EntryFilter {
         if (matches) {
           return FilterResult.ACCEPT;
         }
-        if (selectorIsOnConsumer) {
-          return FilterResult.RESCHEDULE;
-        } else {
-          return FilterResult.REJECT;
-        }
+        return rejectResult;
       }
 
     } catch (Throwable err) {

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -29,10 +29,12 @@ import java.util.Map;
 import javax.jms.Destination;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
 
+@Slf4j
 public class DockerTest {
 
   private static final String TEST_PULSAR_DOCKER_IMAGE_NAME =
@@ -101,6 +103,7 @@ public class DockerTest {
 
   private void test(String image, boolean transactions, boolean useServerSideFiltering)
       throws Exception {
+    log.info("Classpath: {}", System.getProperty("java.class.path"));
     try (PulsarContainer pulsarContainer =
         new PulsarContainer(image, transactions, useServerSideFiltering, tempDir); ) {
       pulsarContainer.start();

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -96,17 +96,17 @@ public class DockerTest {
     test(image, transactions, false);
   }
 
-  private void test(String image, boolean transactions, boolean serverSideSelectors)
+  private void test(String image, boolean transactions, boolean useServerSideFiltering)
       throws Exception {
     try (PulsarContainer pulsarContainer =
-        new PulsarContainer(image, transactions, serverSideSelectors, tempDir); ) {
+        new PulsarContainer(image, transactions, useServerSideFiltering, tempDir); ) {
       pulsarContainer.start();
       Map<String, Object> properties = new HashMap<>();
       properties.put("brokerServiceUrl", pulsarContainer.getPulsarBrokerUrl());
       properties.put("webServiceUrl", pulsarContainer.getHttpServiceUrl());
       properties.put("enableTransaction", transactions);
-      if (serverSideSelectors) {
-        properties.put("jms.useServerSideSelectors", true);
+      if (useServerSideFiltering) {
+        properties.put("jms.useServerSideFiltering", true);
       }
 
       // here we are using the repackaged Pulsar client and actually the class name is
@@ -149,7 +149,7 @@ public class DockerTest {
               (PulsarMessageConsumer.PulsarJMSConsumer) consumerWithSelector;
           PulsarMessageConsumer inner = pulsarJMSConsumer.asPulsarMessageConsumer();
 
-          if (serverSideSelectors) {
+          if (useServerSideFiltering) {
             // the message is not sent to the client at all
             assertEquals(1, inner.getReceivedMessages());
             assertEquals(0, inner.getSkippedMessages());

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -57,7 +57,7 @@ public class DockerTest {
 
   @Test
   public void testPulsar2101() throws Exception {
-    test("eolivelli/pulsar:latest-branch-2.10", false);
+    test("eolivelli/pulsar:branch-2.10-pip105-enhanced", false);
   }
 
   @Test
@@ -72,12 +72,12 @@ public class DockerTest {
 
   @Test
   public void testPulsar2101Transactions() throws Exception {
-    test("eolivelli/pulsar:latest-branch-2.10", true);
+    test("eolivelli/pulsar:branch-2.10-pip105-enhanced", true);
   }
 
   @Test
   public void testPulsar2101ServerSideSelectors() throws Exception {
-    test("eolivelli/pulsar:latest-branch-2.10", false, true);
+    test("eolivelli/pulsar:branch-2.10-pip105-enhanced", false, true);
   }
 
   @Test

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -58,7 +58,7 @@ public class DockerTest {
   @Test
   public void testPulsar2101() throws Exception {
     // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
-    test("datastax/lunastreaming:2.10.0.1", false);
+    test("datastax/lunastreaming:2.10_0.1", false);
   }
 
   @Test
@@ -74,13 +74,13 @@ public class DockerTest {
   @Test
   public void testPulsar2101Transactions() throws Exception {
     // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
-    test("datastax/lunastreaming:2.10.0.1", true);
+    test("datastax/lunastreaming:2.10_0.1", true);
   }
 
   @Test
   public void testPulsar2101ServerSideSelectors() throws Exception {
     // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
-    test("datastax/lunastreaming:2.10.0.1", false, true);
+    test("datastax/lunastreaming:2.10_0.1", false, true);
   }
 
   @Test

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -57,7 +57,8 @@ public class DockerTest {
 
   @Test
   public void testPulsar2101() throws Exception {
-    test("eolivelli/pulsar:branch-2.10-pip105-enhanced", false);
+    // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
+    test("datastax/lunastreaming:2.10.0.1", false);
   }
 
   @Test
@@ -72,12 +73,14 @@ public class DockerTest {
 
   @Test
   public void testPulsar2101Transactions() throws Exception {
-    test("eolivelli/pulsar:branch-2.10-pip105-enhanced", true);
+    // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
+    test("datastax/lunastreaming:2.10.0.1", true);
   }
 
   @Test
   public void testPulsar2101ServerSideSelectors() throws Exception {
-    test("eolivelli/pulsar:branch-2.10-pip105-enhanced", false, true);
+    // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
+    test("datastax/lunastreaming:2.10.0.1", false, true);
   }
 
   @Test

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -942,17 +942,19 @@ public class PulsarConnectionFactory
         consumerMetadata.put("jms.filter.JMSConnectionID", jmsConnectionID);
       }
     }
-    if (messageSelector != null && isUseServerSideFiltering()) {
-      consumerMetadata.put("jms.selector", messageSelector);
+    if (isUseServerSideFiltering()) {
+      if (messageSelector != null) {
+        consumerMetadata.put("jms.selector", messageSelector);
+      }
       if (destination.isTopic()) {
-        consumerMetadata.put("jms.reject.action", "drop");
+        consumerMetadata.put("jms.selector.reject.action", "drop");
       } else {
         // for Queue is it on the Consumer
-        consumerMetadata.put("jms.reject.action", "reschedule");
+        consumerMetadata.put("jms.selector.reject.action", "reschedule");
       }
     }
     if (isAcknowledgeRejectedMessages()) {
-      consumerMetadata.put("jms.reject.action", "drop");
+      consumerMetadata.put("jms.force.drop.rejected", "true");
     }
 
     try {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -900,15 +900,15 @@ public class PulsarConnectionFactory
   }
 
   public Consumer<byte[]> createConsumer(
-          PulsarDestination destination,
-          String consumerName,
-          int sessionMode,
-          SubscriptionMode subscriptionMode,
-          SubscriptionType subscriptionType,
-          String messageSelector,
-          boolean noLocal,
-          String jmsConnectionID,
-          AtomicReference<String> selectorOnSubscriptionReceiver)
+      PulsarDestination destination,
+      String consumerName,
+      int sessionMode,
+      SubscriptionMode subscriptionMode,
+      SubscriptionType subscriptionType,
+      String messageSelector,
+      boolean noLocal,
+      String jmsConnectionID,
+      AtomicReference<String> selectorOnSubscriptionReceiver)
       throws JMSException {
     String fullQualifiedTopicName = applySystemNamespace(destination.topicName);
     // for queues we have a single shared subscription
@@ -960,22 +960,27 @@ public class PulsarConnectionFactory
     }
 
     try {
-      if (isUseServerSideFiltering()
-              && subscriptionMode == SubscriptionMode.Durable) {
+      if (isUseServerSideFiltering() && subscriptionMode == SubscriptionMode.Durable) {
         try {
-          Map<String, ? extends SubscriptionStats> subscriptions
-                  = pulsarAdmin.topics().getStats(fullQualifiedTopicName).getSubscriptions();
+          Map<String, ? extends SubscriptionStats> subscriptions =
+              pulsarAdmin.topics().getStats(fullQualifiedTopicName).getSubscriptions();
           SubscriptionStats subscriptionStats = subscriptions.get(subscriptionName);
           if (subscriptionStats != null) {
-            Map<String, String> subscriptionPropertiesFromBroker = subscriptionStats.getSubscriptionProperties();
+            Map<String, String> subscriptionPropertiesFromBroker =
+                subscriptionStats.getSubscriptionProperties();
             log.info("subscriptionPropertiesFromBroker {}", subscriptionPropertiesFromBroker);
             if (subscriptionPropertiesFromBroker != null) {
-              boolean filtering = "true".equals(subscriptionPropertiesFromBroker.get("jms.filtering"));
+              boolean filtering =
+                  "true".equals(subscriptionPropertiesFromBroker.get("jms.filtering"));
               if (filtering) {
-                String selectorOnSubscription = subscriptionPropertiesFromBroker.getOrDefault("jms.selector", "");
+                String selectorOnSubscription =
+                    subscriptionPropertiesFromBroker.getOrDefault("jms.selector", "");
                 if (!selectorOnSubscription.isEmpty()) {
-                  log.info("Detected selector {} on Subscription {} on topic {}", selectorOnSubscription,
-                          subscriptionName, fullQualifiedTopicName);
+                  log.info(
+                      "Detected selector {} on Subscription {} on topic {}",
+                      selectorOnSubscription,
+                      subscriptionName,
+                      fullQualifiedTopicName);
                   selectorOnSubscriptionReceiver.set(selectorOnSubscription);
                 }
               }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -930,22 +930,20 @@ public class PulsarConnectionFactory
     Map<String, String> subscriptionProperties = new HashMap<>();
     Map<String, String> consumerMetadata = new HashMap<>();
     consumerMetadata.put("jms.destination.type", destination.isQueue() ? "queue" : "topic");
-    if (isAcknowledgeRejectedMessages()) {
-      consumerMetadata.put("jms.reject.action", "drop");
-    } else {
-      consumerMetadata.put("jms.reject.action", "reschedule");
-    }
     if (isUseServerSideSelectors()) {
       subscriptionProperties.put("jms.destination.type", destination.isQueue() ? "queue" : "topic");
     }
     if (messageSelector != null && isUseServerSideSelectors()) {
+      consumerMetadata.put("jms.selector", messageSelector);
       if (destination.isTopic()) {
-        // for Topic Consumers we set the selector on the Subscription
-        subscriptionProperties.put("jms.selector", messageSelector);
+        consumerMetadata.put("jms.reject.action", "drop");
       } else {
         // for Queue is it on the Consumer
-        consumerMetadata.put("jms.selector", messageSelector);
+        consumerMetadata.put("jms.reject.action", "reschedule");
       }
+    }
+    if (isAcknowledgeRejectedMessages()) {
+      consumerMetadata.put("jms.reject.action", "drop");
     }
 
     try {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -138,17 +138,19 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
                   session.getAcknowledgeMode(),
                   subscriptionMode,
                   subscriptionType,
-                      currentSelector,
+                  currentSelector,
                   noLocal,
                   session.getConnection().getConnectionId(),
                   selectorOnSubscriptionReceiver);
       String jmsSelectorOnSubscription = selectorOnSubscriptionReceiver.get();
       if (jmsSelectorOnSubscription != null && !jmsSelectorOnSubscription.isEmpty()) {
         if (currentSelector != null && !currentSelector.isEmpty()) {
-           if (!currentSelector.equals(jmsSelectorOnSubscription)) {
-             throw new javax.jms.InvalidSelectorException("If you set locally a selector it must match" +
-                     "  the selector set at subscription level, in this case it is " + jmsSelectorOnSubscription);
-           }
+          if (!currentSelector.equals(jmsSelectorOnSubscription)) {
+            throw new javax.jms.InvalidSelectorException(
+                "If you set locally a selector it must match"
+                    + "  the selector set at subscription level, in this case it is "
+                    + jmsSelectorOnSubscription);
+          }
         }
         selectorSupport = SelectorSupport.build(jmsSelectorOnSubscription, true);
       }
@@ -168,8 +170,7 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
   @Override
   public synchronized String getMessageSelector() throws JMSException {
     checkNotClosed();
-    if (destination.isQueue()
-            && session.getFactory().isUseServerSideFiltering()) {
+    if (destination.isQueue() && session.getFactory().isUseServerSideFiltering()) {
       // ensure we download properly the selector from the server
       getConsumer();
     }
@@ -376,6 +377,7 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
               + ",) cannot be converted to a "
               + expectedType);
     }
+    SelectorSupport selectorSupport = getSelectorSupport();
     if (selectorSupport != null
         && requiresClientSideFiltering(message)
         && !selectorSupport.matches(result)) {
@@ -637,6 +639,10 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
 
   PulsarSession getSession() {
     return session;
+  }
+
+  private synchronized SelectorSupport getSelectorSupport() {
+    return selectorSupport;
   }
 
   Consumer<byte[]> getInternalConsumer() {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -485,10 +485,6 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
         throw new InvalidDestinationException("destination is null");
       }
     }
-    if (timeToLive > 0 && !session.getFactory().isEnableClientSideEmulation()) {
-      throw new JMSException(
-          "timeToLive not enabled, please set jms.enableClientSideEmulation=true");
-    }
   }
 
   /**

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/NoLocalTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/NoLocalTest.java
@@ -38,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -65,16 +64,16 @@ public class NoLocalTest {
 
   private static Stream<Arguments> combinations() {
     return Stream.of(
-            Arguments.of(true, true),
-            Arguments.of(false, true),
-            Arguments.of(true, false),
-            Arguments.of(false, false));
+        Arguments.of(true, true),
+        Arguments.of(false, true),
+        Arguments.of(true, false),
+        Arguments.of(false, false));
   }
-
 
   @ParameterizedTest(name = "{index} useServerSideFiltering {0} enableBatching {1}")
   @MethodSource("combinations")
-  public void sendMessageReceiveFromQueueWithNoLocal(boolean useServerSideFiltering, boolean enableBatching) throws Exception {
+  public void sendMessageReceiveFromQueueWithNoLocal(
+      boolean useServerSideFiltering, boolean enableBatching) throws Exception {
     useServerSideFiltering = false;
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
@@ -120,7 +119,8 @@ public class NoLocalTest {
 
   @ParameterizedTest(name = "{index} useServerSideFiltering {0} enableBatching {1}")
   @MethodSource("combinations")
-  public void sendMessageReceiveFromTopicWithNoLocal(boolean useServerSideFiltering, boolean enableBatching) throws Exception {
+  public void sendMessageReceiveFromTopicWithNoLocal(
+      boolean useServerSideFiltering, boolean enableBatching) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
@@ -167,7 +167,8 @@ public class NoLocalTest {
 
   @ParameterizedTest(name = "{index} useServerSideFiltering {0} enableBatching {1}")
   @MethodSource("combinations")
-  public void sendMessageReceiveFromExclusiveSubscriptionWithSelector(boolean useServerSideFiltering, boolean enableBatching) throws Exception {
+  public void sendMessageReceiveFromExclusiveSubscriptionWithSelector(
+      boolean useServerSideFiltering, boolean enableBatching) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
@@ -215,7 +216,8 @@ public class NoLocalTest {
 
   @ParameterizedTest(name = "{index} useServerSideFiltering {0} enableBatching {1}")
   @MethodSource("combinations")
-  public void sendMessageReceiveFromSharedSubscriptionWithNoLocal(boolean useServerSideFiltering, boolean enableBatching) throws Exception {
+  public void sendMessageReceiveFromSharedSubscriptionWithNoLocal(
+      boolean useServerSideFiltering, boolean enableBatching) throws Exception {
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
     properties.put("jms.enableClientSideEmulation", !useServerSideFiltering);
@@ -260,25 +262,25 @@ public class NoLocalTest {
     }
   }
 
-
   private static Stream<Arguments> acknowledgeRejectedMessagesTestCombinations() {
     return Stream.of(
-            Arguments.of(true, true, true),
-            Arguments.of(false, true, true),
-            Arguments.of(true, false, true),
-            Arguments.of(false, false, true),
-            Arguments.of(true, true, false),
-            Arguments.of(false, true, false),
-            Arguments.of(true, false, false),
-            Arguments.of(false, false, false)
-    );
+        Arguments.of(true, true, true),
+        Arguments.of(false, true, true),
+        Arguments.of(true, false, true),
+        Arguments.of(false, false, true),
+        Arguments.of(true, true, false),
+        Arguments.of(false, true, false),
+        Arguments.of(true, false, false),
+        Arguments.of(false, false, false));
   }
 
-  @ParameterizedTest(name = "{index} useServerSideFiltering {0} enableBatching {1} acknowledgeRejectedMessages {2}")
+  @ParameterizedTest(
+    name = "{index} useServerSideFiltering {0} enableBatching {1} acknowledgeRejectedMessages {2}"
+  )
   @MethodSource("acknowledgeRejectedMessagesTestCombinations")
-  public void acknowledgeRejectedMessagesTest(boolean useServerSideFiltering,
-                                              boolean enableBatching,
-                                              boolean acknowledgeRejectedMessages) throws Exception {
+  public void acknowledgeRejectedMessagesTest(
+      boolean useServerSideFiltering, boolean enableBatching, boolean acknowledgeRejectedMessages)
+      throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -49,11 +49,11 @@ public abstract class SelectorsTestsBase {
   @TempDir public static Path tempDir;
   private static PulsarCluster cluster;
 
-  private final boolean serverSideSelectors;
+  private final boolean useServerSideFiltering;
   private final boolean enableBatching;
 
-  public SelectorsTestsBase(boolean serverSideSelectors, boolean enableBatching) {
-    this.serverSideSelectors = serverSideSelectors;
+  public SelectorsTestsBase(boolean useServerSideFiltering, boolean enableBatching) {
+    this.useServerSideFiltering = useServerSideFiltering;
     this.enableBatching = enableBatching;
   }
 
@@ -74,8 +74,8 @@ public abstract class SelectorsTestsBase {
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
 
-    properties.put("jms.useServerSideSelectors", serverSideSelectors);
-    properties.put("jms.enableClientSideEmulation", !serverSideSelectors);
+    properties.put("jms.useServerSideFiltering", useServerSideFiltering);
+    properties.put("jms.enableClientSideEmulation", !useServerSideFiltering);
 
     Map<String, Object> producerConfig = new HashMap<>();
     producerConfig.put("batchingEnabled", enableBatching);
@@ -88,7 +88,7 @@ public abstract class SelectorsTestsBase {
     Map<String, Object> properties = buildProperties();
 
     // ensure that we don't ask for enableClientSideEmulation in this case
-    properties.put("jms.enableClientSideEmulation", !serverSideSelectors);
+    properties.put("jms.enableClientSideEmulation", !useServerSideFiltering);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
       try (PulsarConnection connection = factory.createConnection()) {
         connection.start();
@@ -115,7 +115,7 @@ public abstract class SelectorsTestsBase {
             TextMessage textMessage = (TextMessage) consumer1.receive();
             assertEquals("foo-9", textMessage.getText());
 
-            if (serverSideSelectors) {
+            if (useServerSideFiltering) {
               assertEquals(1, consumer1.getReceivedMessages());
               assertEquals(0, consumer1.getSkippedMessages());
             } else {
@@ -171,7 +171,7 @@ public abstract class SelectorsTestsBase {
             TextMessage textMessage = (TextMessage) consumer1.receive();
             assertEquals("foo-9", textMessage.getText());
 
-            if (serverSideSelectors) {
+            if (useServerSideFiltering) {
               assertEquals(1, consumer1.getReceivedMessages());
               assertEquals(0, consumer1.getSkippedMessages());
             } else {
@@ -223,7 +223,7 @@ public abstract class SelectorsTestsBase {
             TextMessage textMessage = (TextMessage) consumer1.receive();
             assertEquals("foo-9", textMessage.getText());
 
-            if (serverSideSelectors) {
+            if (useServerSideFiltering) {
               assertEquals(1, consumer1.getReceivedMessages());
               assertEquals(0, consumer1.getSkippedMessages());
             } else {
@@ -273,7 +273,7 @@ public abstract class SelectorsTestsBase {
             TextMessage textMessage = (TextMessage) consumer1.receive();
             assertEquals("foo-9", textMessage.getText());
 
-            if (serverSideSelectors) {
+            if (useServerSideFiltering) {
               assertEquals(1, consumer1.getReceivedMessages());
               assertEquals(0, consumer1.getSkippedMessages());
             } else {
@@ -360,7 +360,7 @@ public abstract class SelectorsTestsBase {
             // no more messages (this also drains some remaining messages to be skipped)
             assertNull(consumer1.receive(1000));
 
-            if (serverSideSelectors) {
+            if (useServerSideFiltering) {
               if (enableBatching) {
                 // unfortunately the server could not reject any batch
                 assertEquals(100, consumer1.getReceivedMessages());
@@ -452,7 +452,7 @@ public abstract class SelectorsTestsBase {
             // no more messages (this also drains some remaining messages to be skipped)
             assertNull(consumer1.receive(1000));
 
-            if (serverSideSelectors) {
+            if (useServerSideFiltering) {
               // even with batching the client
               // receives exactly only the messages that match the filter
               assertEquals(expected.size(), consumer1.getReceivedMessages());

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -492,7 +492,10 @@ public abstract class SelectorsTestsBase {
     subscriptionProperties.put("jms.filtering", "true");
 
     // create a Subscription with a selector
-    try (Consumer<byte[]> dummy = cluster.getService().getClient()
+    try (Consumer<byte[]> dummy =
+        cluster
+            .getService()
+            .getClient()
             .newConsumer()
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
@@ -508,15 +511,13 @@ public abstract class SelectorsTestsBase {
       try (PulsarConnection connection = factory.createConnection()) {
         connection.start();
         try (PulsarSession session = connection.createSession(); ) {
-          Topic destination =
-                  session.createTopic(topicName);
+          Topic destination = session.createTopic(topicName);
 
           // do not set the selector, it will be loaded from the Subscription Properties
           try (PulsarMessageConsumer consumer1 =
-                       session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
+              session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
             assertEquals(
-                    SubscriptionType.Shared,
-                    ((PulsarMessageConsumer) consumer1).getSubscriptionType());
+                SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
             // this is downloaded from the server
             assertEquals(selector, consumer1.getMessageSelector());
@@ -537,7 +538,6 @@ public abstract class SelectorsTestsBase {
                 assertEquals("foo-" + i, textMessage.getText());
               }
             }
-
 
             assertEquals(5, consumer1.getReceivedMessages());
             assertEquals(0, consumer1.getSkippedMessages());
@@ -573,7 +573,10 @@ public abstract class SelectorsTestsBase {
     subscriptionProperties.put("jms.filtering", "true");
 
     // create a Subscription with a selector
-    try (Consumer<byte[]> dummy = cluster.getService().getClient()
+    try (Consumer<byte[]> dummy =
+        cluster
+            .getService()
+            .getClient()
             .newConsumer()
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
@@ -589,15 +592,12 @@ public abstract class SelectorsTestsBase {
       try (PulsarConnection connection = factory.createConnection()) {
         connection.start();
         try (PulsarSession session = connection.createSession(); ) {
-          Queue destination =
-                  session.createQueue(topicName);
+          Queue destination = session.createQueue(topicName);
 
           // do not set the selector, it will be loaded from the Subscription Properties
-          try (PulsarMessageConsumer consumer1 =
-                       session.createConsumer(destination); ) {
+          try (PulsarMessageConsumer consumer1 = session.createConsumer(destination); ) {
             assertEquals(
-                    SubscriptionType.Shared,
-                    ((PulsarMessageConsumer) consumer1).getSubscriptionType());
+                SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
             // this is downloaded from the server
             assertEquals(selector, consumer1.getMessageSelector());

--- a/tck-executor/start_pulsar.sh
+++ b/tck-executor/start_pulsar.sh
@@ -2,7 +2,7 @@
 
 set -x -e
 
-IMAGENAME=${PULSAR_IMAGE_NAME:-eolivelli/pulsar:latest-branch-2.10}
+IMAGENAME=${PULSAR_IMAGE_NAME:-eolivelli/pulsar:branch-2.10-pip105-enhanced}
 
 HERE=$(dirname $0)
 HERE=$(realpath "$HERE")

--- a/tck-executor/start_pulsar.sh
+++ b/tck-executor/start_pulsar.sh
@@ -2,7 +2,8 @@
 
 set -x -e
 
-IMAGENAME=${PULSAR_IMAGE_NAME:-eolivelli/pulsar:branch-2.10-pip105-enhanced}
+# waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
+IMAGENAME=${PULSAR_IMAGE_NAME:-datastax/pulsar:2.10.0.1}
 
 HERE=$(dirname $0)
 HERE=$(realpath "$HERE")

--- a/tck-executor/start_pulsar.sh
+++ b/tck-executor/start_pulsar.sh
@@ -3,7 +3,7 @@
 set -x -e
 
 # waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
-IMAGENAME=${PULSAR_IMAGE_NAME:-datastax/pulsar:2.10_0.1}
+IMAGENAME=${PULSAR_IMAGE_NAME:-datastax/lunastreaming:2.10_0.1}
 
 HERE=$(dirname $0)
 HERE=$(realpath "$HERE")

--- a/tck-executor/start_pulsar.sh
+++ b/tck-executor/start_pulsar.sh
@@ -3,7 +3,7 @@
 set -x -e
 
 # waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
-IMAGENAME=${PULSAR_IMAGE_NAME:-datastax/pulsar:2.10.0.1}
+IMAGENAME=${PULSAR_IMAGE_NAME:-datastax/pulsar:2.10_0.1}
 
 HERE=$(dirname $0)
 HERE=$(realpath "$HERE")

--- a/tck-executor/ts.serverSideFilters.jte
+++ b/tck-executor/ts.serverSideFilters.jte
@@ -170,7 +170,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
 		-Djava.security.policy="${bin.dir}/harness.policy" \
 		-Djava.security.manager \
 		-Dlog4j2.debug=true \
-                -DJMS_TCK_CLIENT_jms_useServerSideSelectors=true \
+                -DJMS_TCK_CLIENT_jms_useServerSideFiltering=true \
 		-Dorg.slf4j.simpleLogger.defaultLogLevel=warn \
 		-Djava.naming.factory.initial=${java.naming.factory.initial} \
 		-Ddeliverable.class=${deliverable.class} \


### PR DESCRIPTION
Modifications:
Push to the broker side all the remaining filters (NoLocal, TimeToLive and Selectors for Queues)

Notes:
- It requires an additional API change to EntryFilter.FilterResult, the RESCHEDULE outcome
https://github.com/apache/pulsar/pull/15391
- We are using this docker image (eolivelli/pulsar:branch-2.10-pip105-enhanced) that contains #15391