### PR TITLE
Reduce memory allocations and CPU Cycles for Message Selectors on the Broker and on the Client

### DIFF
--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -565,7 +565,8 @@ public abstract class SelectorsTestsBase {
     // because it is always safe
     properties.put("jms.enableClientSideEmulation", "false");
 
-    String topicName = "sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue_" + enableBatching;
+    String topicName =
+        "sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue_" + enableBatching;
     cluster.getService().getAdminClient().topics().createNonPartitionedTopic(topicName);
 
     String subscriptionName = "the-sub";
@@ -581,7 +582,10 @@ public abstract class SelectorsTestsBase {
             .getService()
             .getClient()
             .newConsumer()
-            .subscriptionName(topicName + ":" + subscriptionName) // real subscription name is short topic name + subname
+            .subscriptionName(
+                topicName
+                    + ":"
+                    + subscriptionName) // real subscription name is short topic name + subname
             .subscriptionType(SubscriptionType.Shared)
             .subscriptionMode(SubscriptionMode.Durable)
             .subscriptionProperties(subscriptionProperties)


### PR DESCRIPTION
Modifications:
Override some useless ActiveMQ methods in order to save memory copies, CPU cycles and synchronised methods

Motivations:
- ActiveMQMessage does reference counting and this is useless for Pulsar
- The Selectors (PropertyExpression) uses only System Message Properties and Message.getProperty(), there is no need to build the internal  ActiveMQMessage properties structure, that implies building intermediate data structures and also re-encoding

see the attached async profiler report taken from a Pulsar broker
[profile.html.zip](https://github.com/datastax/pulsar-jms/files/8715385/profile.html.zip)

