### PR TITLE
New Mode INDIVIDUAL_ACKNOWLEDGE

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSConstants.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import javax.jms.Message;
+
+public final class PulsarJMSConstants {
+
+  /**
+   * This is an extended mode for the Session and JMSContext in which {@link Message#acknowledge()}
+   * acknowledges only the single message and the message and the other messages dispatched to the
+   * Session.
+   */
+  public static final int INDIVIDUAL_ACKNOWLEDGE = 4;
+
+  private PulsarJMSConstants() {}
+}

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -1069,7 +1069,11 @@ public abstract class PulsarMessage implements Message {
   @Override
   public void acknowledge() throws JMSException {
     consumer.checkNotClosed();
-    consumer.getSession().acknowledgeAllMessages();
+    if (consumer.getSession().getAcknowledgeMode() == PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE) {
+      acknowledgeInternal();
+    } else {
+      consumer.getSession().acknowledgeAllMessages();
+    }
   }
 
   void acknowledgeInternal() throws JMSException {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -442,6 +442,7 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
               });
     }
     if (session.getAcknowledgeMode() != Session.CLIENT_ACKNOWLEDGE
+        && session.getAcknowledgeMode() != PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE
         && session.getAcknowledgeMode() != Session.SESSION_TRANSACTED) {
       session.unregisterUnacknowledgedMessage(result);
     }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -145,6 +145,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
       case Session.SESSION_TRANSACTED:
       case Session.AUTO_ACKNOWLEDGE:
       case Session.CLIENT_ACKNOWLEDGE:
+      case PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE:
       case Session.DUPS_OK_ACKNOWLEDGE:
         break;
       default:

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/AcknowledgementModeTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/AcknowledgementModeTest.java
@@ -187,6 +187,10 @@ public class AcknowledgementModeTest {
             TextMessage textMsg = session.createTextMessage("foo");
             textMsg.setStringProperty("test", "foo");
             producer.send(textMsg);
+
+            TextMessage textMsg2 = session.createTextMessage("foo");
+            textMsg2.setStringProperty("test", "foo2");
+            producer.send(textMsg2);
           }
 
           try (MessageConsumer consumer = session.createConsumer(destination); ) {
@@ -200,11 +204,71 @@ public class AcknowledgementModeTest {
             // receive and ack
             Message receive = consumer.receive();
             assertEquals("foo", receive.getStringProperty("test"));
+
+            Message receive2 = consumer.receive();
+            assertEquals("foo2", receive2.getStringProperty("test"));
+
+            // ack only message1, this automatically acks all the other messages
             receive.acknowledge();
           }
 
           // no more messages
           try (MessageConsumer consumer = session.createConsumer(destination); ) {
+            assertNull(consumer.receive(100));
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testINDIVIDUAL_ACKNOWLEDGE() throws Exception {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (Connection connection = factory.createConnection()) {
+        connection.start();
+        try (Session session =
+            connection.createSession(PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE); ) {
+          Queue destination =
+              session.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+
+          try (MessageProducer producer = session.createProducer(destination); ) {
+            TextMessage textMsg = session.createTextMessage("foo");
+            textMsg.setStringProperty("test", "foo");
+            producer.send(textMsg);
+
+            TextMessage textMsg2 = session.createTextMessage("foo");
+            textMsg2.setStringProperty("test", "foo2");
+            producer.send(textMsg2);
+          }
+
+          try (MessageConsumer consumer = session.createConsumer(destination); ) {
+            assertEquals("foo", consumer.receive().getStringProperty("test"));
+            // message is not automatically acknowledged on receive
+
+            // closing the consumer
+          }
+
+          try (MessageConsumer consumer = session.createConsumer(destination); ) {
+            // receive and ack
+            Message receive = consumer.receive();
+            assertEquals("foo", receive.getStringProperty("test"));
+
+            Message receive2 = consumer.receive();
+            assertEquals("foo2", receive2.getStringProperty("test"));
+
+            // ack only message1,
+            receive.acknowledge();
+          }
+
+          // no more messages
+          try (MessageConsumer consumer = session.createConsumer(destination); ) {
+
+            // message2 is still there
+            Message receive2 = consumer.receive();
+            assertEquals("foo2", receive2.getStringProperty("test"));
+
             assertNull(consumer.receive(100));
           }
         }


### PR DESCRIPTION
Modifications:
- Add a new Session/JMSContext mode PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE
- In this mode Message.acknowledge() maps to the standard individual acknowledgement of the Message in Pulsar
- This is different from Session.CLIENT_ACKNOWLEDGE, because the standard mode implies to acknowledge all the other messages dispatched to the same Session (see JavaDocs of javax.jms.Message)

This is very similar to ActiveMQ extension INDIVIDUAL_ACKNOWLEDGE 
https://activemq.apache.org/components/artemis/documentation/latest/pre-acknowledge.html