### PR TITLE
Add tests for huge consumer side selectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- waiting for a Apache Pulsar 2.10.1 release, in the meantime we use DataStax Luna Streaming
          that is a fork of Apache Pulsar  -->
     <pulsar.groupId>com.datastax.oss</pulsar.groupId>
-    <pulsar.version>2.10.0.4-SNAPSHOT</pulsar.version>
+    <pulsar.version>2.10.0.4</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- waiting for a Apache Pulsar 2.10.1 release, in the meantime we use DataStax Luna Streaming
          that is a fork of Apache Pulsar  -->
     <pulsar.groupId>com.datastax.oss</pulsar.groupId>
-    <pulsar.version>2.10.0.2</pulsar.version>
+    <pulsar.version>2.10.0.4-SNAPSHOT</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -74,15 +74,15 @@ public class DockerTest {
   }
 
   @Test
-  public void testPulsar2101Transactions() throws Exception {
+  public void testLunaStreaming210Transactions() throws Exception {
     // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
-    test("datastax/lunastreaming:2.10_0.1", true);
+    test("datastax/lunastreaming:2.10_0.4", true);
   }
 
   @Test
-  public void testPulsar2101ServerSideSelectors() throws Exception {
+  public void testLunaStreaming210ServerSideSelectors() throws Exception {
     // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.1
-    test("datastax/lunastreaming:2.10_0.1", false, true);
+    test("datastax/lunastreaming:2.10_0.4", false, true);
   }
 
   @Test

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -1072,8 +1072,6 @@ public abstract class SelectorsTestsBase {
     }
   }
 
-  // waiting for 2.10.0.4 with
-  // https://github.com/apache/pulsar/pull/15713
   @Test
   public void sendHugeFilterOnConsumerMetadata() throws Exception {
     // we are testing here that we can store a huge (10k) filter on the Consumer Metadata

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/utils/PulsarCluster.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/utils/PulsarCluster.java
@@ -61,6 +61,7 @@ public class PulsarCluster implements AutoCloseable {
     config.setEntryFilterNames(Arrays.asList("jms"));
     config.setEntryFiltersDirectory("target/classes/filters");
     config.setAcknowledgmentAtBatchIndexLevelEnabled(true);
+    config.setMaxConsumerMetadataSize(1024 * 1024);
     service = new PulsarService(config);
   }
 


### PR DESCRIPTION
- Update dependency to Luna Streaming 2.10.0.4
- Add test case with 10K long Consumer selector (stored on Consumer metadata) 