### PR TITLE
Add tests about PIP-54 feature batchIndexAckEnabled

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -1580,7 +1580,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
       getFactory().removeConsumer(pulsarConsumer);
       for (Iterator<PulsarMessage> it = unackedMessages.iterator(); it.hasNext(); ) {
         PulsarMessage message = it.next();
-        if (message.isReceivedFromConsumer(consumer)) {
+        if (message != null && message.isReceivedFromConsumer(consumer)) {
           it.remove();
         }
       }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -431,7 +431,7 @@ public abstract class SelectorsTestsBase {
             List<String> expected1 = new CopyOnWriteArrayList<>();
             List<String> expected2 = new CopyOnWriteArrayList<>();
             try (MessageProducer producer = session.createProducer(destination); ) {
-              for (int i = 0; i < 100; i++) {
+              for (int i = 0; i < 10; i++) {
                 String text = "foo-" + i;
                 TextMessage textMessage = session.createTextMessage(text);
                 // some messages go to consumer 1

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/utils/PulsarCluster.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/utils/PulsarCluster.java
@@ -60,6 +60,7 @@ public class PulsarCluster implements AutoCloseable {
     config.setBookkeeperUseV2WireProtocol(false);
     config.setEntryFilterNames(Arrays.asList("jms"));
     config.setEntryFiltersDirectory("target/classes/filters");
+    config.setAcknowledgmentAtBatchIndexLevelEnabled(true);
     service = new PulsarService(config);
   }
 

--- a/pulsar-jms/src/test/resources/log4j2.xml
+++ b/pulsar-jms/src/test/resources/log4j2.xml
@@ -29,11 +29,13 @@
     <logger name="org.apache.bookkeeper" level="error" additivity="true"/>
     <logger name="org.apache.bookkeeper.mledger" level="info" additivity="true"/>
     <logger name="org.apache.pulsar" level="info" additivity="true"/>
-    <logger name="org.apache.zookeeper" level="info" additivity="false"/>
-    <logger name="org.apache.curator" level="error" additivity="false"/>
-    <logger name="org.eclipse.jetty" level="error" additivity="false"/>
+    <logger name="org.apache.zookeeper" level="error" additivity="true"/>
+    <logger name="org.apache.curator" level="error" additivity="true"/>
+    <logger name="org.eclipse.jetty" level="error" additivity="true"/>
     <logger name="org.glassfish.jersey" level="error" additivity="false"/>
+    <logger name="com.datastax.oss.pulsar.jms" level="info" additivity="true"/>
     <logger name="com.datastax.oss.pulsar.jms.utils" level="info" additivity="false"/>
-    <logger name="io.netty" level="error" additivity="false"/>
+    <logger name="io.netty" level="error" additivity="true"/>
+    <logger name="org.asynchttpclient" level="error" additivity="true"/>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
Add tests cases that cover using PIP-54 - https://github.com/apache/pulsar/wiki/PIP-54:-Support-acknowledgment-at-batch-index-level

With PIP-54 the client is able to acknowledge individual messages inside a batch, in order to process correctly `Selectors` and `INDIVIDUAL_ACKNOWLEDGE` mode when using Batching

In order to leverage this feature (PIP-54) you have to set:
- batchIndexAckEnabled=true in the `consumerConfig` on the JMS Client
- acknowledgmentAtBatchIndexLevelEnabled= true in broker.conf