### PR TITLE
Feature: jms.emulateTransactions

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -76,6 +76,7 @@ public class PulsarConnectionFactory
   private String systemNamespace = "public/default";
   private String defaultClientId = null;
   private boolean enableTransaction = false;
+  private boolean emulateTransactions = false;
   private boolean enableClientSideEmulation = false;
   private boolean useServerSideFiltering = false;
   private boolean forceDeleteTemporaryDestinations = false;
@@ -301,6 +302,13 @@ public class PulsarConnectionFactory
       this.enableTransaction =
           Boolean.parseBoolean(configuration.getOrDefault("enableTransaction", "false").toString());
 
+      this.emulateTransactions =
+              Boolean.parseBoolean(getAndRemoveString("jms.emulateTransactions", "false", configuration).toString());
+
+      if (emulateTransactions && enableTransaction) {
+        throw new IllegalStateException("You cannot set both enableTransaction and jms.emulateTransactions");
+      }
+
       String webServiceUrl =
           getAndRemoveString("webServiceUrl", "http://localhost:8080", configuration);
 
@@ -404,6 +412,10 @@ public class PulsarConnectionFactory
 
   public synchronized boolean isEnableTransaction() {
     return enableTransaction;
+  }
+
+  public synchronized boolean isEmulateTransactions() {
+    return emulateTransactions;
   }
 
   public synchronized PulsarClient getPulsarClient() {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -303,10 +303,12 @@ public class PulsarConnectionFactory
           Boolean.parseBoolean(configuration.getOrDefault("enableTransaction", "false").toString());
 
       this.emulateTransactions =
-              Boolean.parseBoolean(getAndRemoveString("jms.emulateTransactions", "false", configuration).toString());
+          Boolean.parseBoolean(
+              getAndRemoveString("jms.emulateTransactions", "false", configuration).toString());
 
       if (emulateTransactions && enableTransaction) {
-        throw new IllegalStateException("You cannot set both enableTransaction and jms.emulateTransactions");
+        throw new IllegalStateException(
+            "You cannot set both enableTransaction and jms.emulateTransactions");
       }
 
       String webServiceUrl =

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -46,6 +46,7 @@ import javax.jms.TopicPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.transaction.Transaction;
 
 @Slf4j
 class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSender {
@@ -1198,7 +1199,13 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
     PulsarMessage pulsarMessage = prepareMessageForSend(message);
     final TypedMessageBuilder<byte[]> typedMessageBuilder;
     if (session.getTransacted()) {
-      typedMessageBuilder = producer.newMessage(session.getTransaction());
+      Transaction transaction = session.getTransaction();
+      if (transaction != null) {
+        typedMessageBuilder = producer.newMessage(transaction);
+      } else {
+        // emulated transactions
+        typedMessageBuilder = producer.newMessage();
+      }
     } else {
       typedMessageBuilder = producer.newMessage();
     }
@@ -1245,7 +1252,13 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
     }
     TypedMessageBuilder<byte[]> typedMessageBuilder;
     if (session.getTransacted()) {
-      typedMessageBuilder = producer.newMessage(session.getTransaction());
+      Transaction transaction = session.getTransaction();
+      if (transaction != null) {
+        typedMessageBuilder = producer.newMessage(transaction);
+      } else {
+        // emulated transactions
+        typedMessageBuilder = producer.newMessage();
+      }
     } else {
       typedMessageBuilder = producer.newMessage();
     }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -99,8 +99,8 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
         emulateTransactions = true;
       } else {
         throw new JMSException(
-                "Please enable transactions on PulsarConnectionFactory with enableTransaction=true, you can configure " +
-                        "jms.emulateTransactions if your Pulsar cluster does not support transactions");
+            "Please enable transactions on PulsarConnectionFactory with enableTransaction=true, you can configure "
+                + "jms.emulateTransactions if your Pulsar cluster does not support transactions");
       }
     } else {
       emulateTransactions = false;
@@ -113,8 +113,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
   }
 
   Transaction getTransaction() throws JMSException {
-    if (transaction == null && sessionMode == SESSION_TRANSACTED
-            && !emulateTransactions) {
+    if (transaction == null && sessionMode == SESSION_TRANSACTED && !emulateTransactions) {
       this.transaction = startTransaction(connection);
     }
     return this.transaction;

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -43,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -708,7 +707,7 @@ public class TransactionsTest {
 
         try (Session consumerSession = connection.createSession(Session.SESSION_TRANSACTED); ) {
           Destination destination =
-                  consumerSession.createTopic("persistent://public/default/test-" + UUID.randomUUID());
+              consumerSession.createTopic("persistent://public/default/test-" + UUID.randomUUID());
           try (MessageConsumer consumer = consumerSession.createConsumer(destination)) {
 
             try (Session transaction = connection.createSession(Session.SESSION_TRANSACTED); ) {

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -257,7 +257,6 @@ public class TransactionsTest {
   }
 
   @Test
-  @Disabled
   public void consumeRollbackTransactionTest() throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
@@ -346,7 +345,6 @@ public class TransactionsTest {
   }
 
   @Test
-  @Disabled
   public void consumeAutoRollbackTransactionTestWithQueueBrowser() throws Exception {
 
     int numMessages = 10;
@@ -494,7 +492,6 @@ public class TransactionsTest {
   }
 
   @Test
-  @Disabled
   public void consumeRollbackTransactionTestWithQueueBrowser() throws Exception {
 
     int numMessages = 10;

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -696,7 +696,7 @@ public class TransactionsTest {
   }
 
   @Test
-  public void emualatedTransactionsTest() throws Exception {
+  public void emulatedTransactionsTest() throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
@@ -720,7 +720,7 @@ public class TransactionsTest {
               }
 
               transaction.commit();
-              // message is now visible to consumers
+
               assertNotNull(consumer.receive());
               assertNotNull(consumer.receive());
 


### PR DESCRIPTION
This is a Proof-of-concept patch for the jms.emulateTransactions feature.

Modifications:
- add new ConnectionFactory option jms.emulateTransactions to emulate transactions
- in this mode when you create a Session in TRANSACTED mode, the Session works like a Transacted session but without a Pulsar transaction
- the behaviour won't be transactional anymore, when you produce you produce immediately (and not at commit) and acks are sent during commit, but not in the context of a transaction
- in Emulated Transactions mode messages are produced immediately and acknowledgements are sent on session.commit89
