### PR TITLE
Lazily evaluate Message Properties

### DIFF
--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -97,8 +97,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -108,8 +108,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -522,15 +522,15 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
     }
     if (!session.isTransactionStarted()) {
       session.executeCriticalOperation(
-              () -> {
-                try {
-                  consumer.close();
-                  session.removeConsumer(this);
-                  return null;
-                } catch (Exception err) {
-                  throw Utils.handleException(err);
-                }
-              });
+          () -> {
+            try {
+              consumer.close();
+              session.removeConsumer(this);
+              return null;
+            } catch (Exception err) {
+              throw Utils.handleException(err);
+            }
+          });
     } else if (session.getTransacted()) {
       closedWhileActiveTransaction = true;
     }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -284,7 +284,6 @@ public class TransactionsTest {
 
               Message receive = consumer.receive();
               assertEquals("foo", receive.getBody(String.class));
-
             }
 
             // rollback transaction AFTER closing the Consumer
@@ -301,7 +300,6 @@ public class TransactionsTest {
     }
   }
 
-
   @Test
   public void consumeRollbackTransaction2Test() throws Exception {
 
@@ -317,7 +315,7 @@ public class TransactionsTest {
 
         try (Session producerSession = connection.createSession(); ) {
           Destination destination =
-                  producerSession.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+              producerSession.createQueue("persistent://public/default/test-" + UUID.randomUUID());
 
           try (Session transaction = connection.createSession(Session.SESSION_TRANSACTED); ) {
 


### PR DESCRIPTION
Motivations:
In order to run the filter we are building a HashMap with all the custom properties and the system properties of the Message.
In benchmarks we saw that now most of the load is due to the allocations and the CPU work that is done to build such HashMap (and also to convert Netty ByteBufs to Strings).

Modifications:
- try to lazing compute a value for Properties only when required (and cache the result)
- add tests