### PR TITLE
[Feature] Add support for leveraging Pulsar Schema Registry while consuming

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
@@ -30,7 +30,7 @@ import org.apache.pulsar.client.api.Reader;
 final class PulsarQueueBrowser implements QueueBrowser {
   private final PulsarSession session;
   private final PulsarQueue queue;
-  private final Reader<byte[]> reader;
+  private final Reader<?> reader;
   private final SelectorSupport selectorSupport;
 
   public PulsarQueueBrowser(PulsarSession session, Queue queue, String selector)

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -1578,7 +1578,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
   }
 
   public void removeConsumer(PulsarMessageConsumer consumer) {
-    Consumer<byte[]> pulsarConsumer = consumer.getInternalConsumer();
+    Consumer<?> pulsarConsumer = consumer.getInternalConsumer();
     if (pulsarConsumer != null) {
       consumers.remove(consumer);
       getFactory().removeConsumer(pulsarConsumer);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/messages/PulsarMapMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/messages/PulsarMapMessage.java
@@ -40,11 +40,18 @@ public final class PulsarMapMessage extends PulsarMessage implements MapMessage 
   }
 
   public PulsarMapMessage(Map<String, Object> body) throws MessageFormatException {
+    this(body, true);
+  }
+
+  public PulsarMapMessage(Map<String, Object> body, boolean validate)
+      throws MessageFormatException {
     this();
     if (body != null) {
       map.putAll(body);
-      for (Object value : body.values()) {
-        validateWritableObject(value);
+      if (validate) {
+        for (Object value : body.values()) {
+          validateWritableObject(value);
+        }
       }
     }
   }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConfigurationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConfigurationTest.java
@@ -75,7 +75,7 @@ public class ConfigurationTest {
         PulsarSession session = connection.createSession()) {
       Queue queue = session.createQueue("test" + UUID.randomUUID());
       try (PulsarMessageConsumer consumer = session.createConsumer(queue); ) {
-        Consumer<byte[]> pulsarConsumer = consumer.getConsumer();
+        Consumer<?> pulsarConsumer = consumer.getConsumer();
         assertEquals("the-consumer-name", pulsarConsumer.getConsumerName());
       }
     }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.jms.BytesMessage;
@@ -29,14 +31,19 @@ import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
+import javax.jms.MapMessage;
 import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+import lombok.Data;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -120,6 +127,215 @@ public class PulsarInteropTest {
             assertArrayEquals(
                 "foo".getBytes(StandardCharsets.UTF_8), message.getBody(byte[].class));
             assertEquals("bar", message.getStringProperty("JMSXGroupID"));
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void stringSchemaTest() throws Exception {
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    Map<String, Object> consumerConfig = new HashMap<>();
+    properties.put("consumerConfig", consumerConfig);
+    consumerConfig.put("useSchema", true);
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (JMSContext context = factory.createContext()) {
+
+        String topic = "persistent://public/default/test-" + UUID.randomUUID();
+        Destination destination = context.createTopic(topic);
+
+        PulsarClient client =
+            cluster
+                .getService()
+                .getClient(); // do not close this client, it is internal to the broker
+        try (JMSConsumer consumer = context.createConsumer(destination)) {
+          try (Producer<String> producer =
+              client.newProducer(Schema.STRING).topic(topic).create(); ) {
+            producer.newMessage().value("foo").key("bar").send();
+
+            // the JMS client reads Schema String as TextMessage
+            TextMessage message = (TextMessage) consumer.receive();
+            assertEquals("foo", message.getText());
+            assertEquals("bar", message.getStringProperty("JMSXGroupID"));
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void longSchemaTest() throws Exception {
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    Map<String, Object> consumerConfig = new HashMap<>();
+    properties.put("consumerConfig", consumerConfig);
+    consumerConfig.put("useSchema", true);
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (JMSContext context = factory.createContext()) {
+
+        String topic = "persistent://public/default/test-" + UUID.randomUUID();
+        Destination destination = context.createTopic(topic);
+
+        PulsarClient client =
+                cluster
+                        .getService()
+                        .getClient(); // do not close this client, it is internal to the broker
+        try (JMSConsumer consumer = context.createConsumer(destination)) {
+          try (Producer<Long> producer =
+                       client.newProducer(Schema.INT64).topic(topic).create(); ) {
+            producer.newMessage().value(23432424L).key("bar").send();
+
+            // the JMS client reads Schema INT64 as ObjectMessage
+            ObjectMessage message = (ObjectMessage) consumer.receive();
+            assertEquals(23432424L, message.getObject());
+            assertEquals("bar", message.getStringProperty("JMSXGroupID"));
+          }
+        }
+      }
+    }
+  }
+
+  @Data
+  static final class Nested {
+    int age;
+    Pojo pojo;
+  }
+
+  @Data
+  static final class Pojo {
+    String name;
+    Nested nested;
+    List<Nested> nestedList;
+  }
+
+  @Test
+  public void avroSchemaTest() throws Exception {
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    Map<String, Object> consumerConfig = new HashMap<>();
+    properties.put("consumerConfig", consumerConfig);
+    consumerConfig.put("useSchema", true);
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (JMSContext context = factory.createContext()) {
+
+        String topic = "persistent://public/default/test-" + UUID.randomUUID();
+        Destination destination = context.createTopic(topic);
+
+        PulsarClient client =
+            cluster
+                .getService()
+                .getClient(); // do not close this client, it is internal to the broker
+        try (JMSConsumer consumer = context.createConsumer(destination)) {
+          try (Producer<Pojo> producer =
+              client.newProducer(Schema.AVRO(Pojo.class)).topic(topic).create(); ) {
+            Pojo pojo = new Pojo();
+            pojo.setName("foo");
+            Nested nested = new Nested();
+            nested.setAge(23);
+
+            Pojo pojo2 = new Pojo();
+            pojo2.setName("foo2");
+            nested.setPojo(pojo2);
+
+            pojo.setNested(nested);
+            pojo.setNestedList(Arrays.asList(nested));
+            producer.newMessage().value(pojo).key("bar").send();
+
+            // the JMS client reads Schema AVRO as TextMessage
+            MapMessage message = (MapMessage) consumer.receive();
+            assertEquals("foo", message.getString("name"));
+            Map<String, Object> nestedValue = (Map<String, Object>) message.getObject("nested");
+            assertEquals(23, nestedValue.get("age"));
+            assertEquals("bar", message.getStringProperty("JMSXGroupID"));
+            Map<String, Object> nestedPojo = (Map<String, Object>) nestedValue.get("pojo");
+            assertEquals("foo2", nestedPojo.get("name"));
+
+            List<Map<String, Object>> nestedValueList =
+                (List<Map<String, Object>>) message.getObject("nestedList");
+            nestedValue = nestedValueList.get(0);
+            assertEquals(23, nestedValue.get("age"));
+            assertEquals("bar", message.getStringProperty("JMSXGroupID"));
+            nestedPojo = (Map<String, Object>) nestedValue.get("pojo");
+            assertEquals("foo2", nestedPojo.get("name"));
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void avroKeyValueSchemaTest() throws Exception {
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    Map<String, Object> consumerConfig = new HashMap<>();
+    properties.put("consumerConfig", consumerConfig);
+    consumerConfig.put("useSchema", true);
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (JMSContext context = factory.createContext()) {
+
+        String topic = "persistent://public/default/test-" + UUID.randomUUID();
+        Destination destination = context.createTopic(topic);
+
+        PulsarClient client =
+            cluster
+                .getService()
+                .getClient(); // do not close this client, it is internal to the broker
+        try (JMSConsumer consumer = context.createConsumer(destination)) {
+          try (Producer<KeyValue<Nested, Pojo>> producer =
+              client
+                  .newProducer(
+                      Schema.KeyValue(
+                          Schema.AVRO(Nested.class),
+                          Schema.AVRO(Pojo.class),
+                          KeyValueEncodingType.INLINE))
+                  .topic(topic)
+                  .create(); ) {
+            Pojo pojo = new Pojo();
+            pojo.setName("foo");
+            Nested nested = new Nested();
+            nested.setAge(23);
+
+            Pojo pojo2 = new Pojo();
+            pojo2.setName("foo2");
+            nested.setPojo(pojo2);
+
+            pojo.setNested(nested);
+            pojo.setNestedList(Arrays.asList(nested));
+
+            KeyValue<Nested, Pojo> keyValue = new KeyValue<>(nested, pojo);
+
+            producer.newMessage().value(keyValue).send();
+
+            // the JMS client reads Schema AVRO as TextMessage
+            MapMessage message = (MapMessage) consumer.receive();
+
+            Map<String, Object> key = (Map<String, Object>) message.getObject("key");
+            assertEquals(23, key.get("age"));
+
+            Map<String, Object> value = (Map<String, Object>) message.getObject("value");
+
+            assertEquals("foo", value.get("name"));
+            Map<String, Object> nestedValue = (Map<String, Object>) value.get("nested");
+            assertEquals(23, nestedValue.get("age"));
+            Map<String, Object> nestedPojo = (Map<String, Object>) nestedValue.get("pojo");
+            assertEquals("foo2", nestedPojo.get("name"));
+
+            List<Map<String, Object>> nestedValueList =
+                (List<Map<String, Object>>) value.get("nestedList");
+            nestedValue = nestedValueList.get(0);
+            assertEquals(23, nestedValue.get("age"));
+            nestedPojo = (Map<String, Object>) nestedValue.get("pojo");
+            assertEquals("foo2", nestedPojo.get("name"));
           }
         }
       }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -673,13 +673,13 @@ public class TransactionsTest {
 
               // verify that the two messages are part of the same batch
               PulsarMessage message1 = (PulsarMessage) consumer.receive();
-              org.apache.pulsar.client.api.Message<byte[]> receivedPulsarMessage1 =
+              org.apache.pulsar.client.api.Message<?> receivedPulsarMessage1 =
                   message1.getReceivedPulsarMessage();
               BatchMessageIdImpl messageId1 =
                   (BatchMessageIdImpl) receivedPulsarMessage1.getMessageId();
 
               PulsarMessage message2 = (PulsarMessage) consumer.receive();
-              org.apache.pulsar.client.api.Message<byte[]> receivedPulsarMessage2 =
+              org.apache.pulsar.client.api.Message<?> receivedPulsarMessage2 =
                   message2.getReceivedPulsarMessage();
               BatchMessageIdImpl messageId2 =
                   (BatchMessageIdImpl) receivedPulsarMessage2.getMessageId();


### PR DESCRIPTION
Motivations:
- JMS API does not have a standard way to consume data driven by a Schema
- Pulsar Client is able to automatically apply the Schema and decode the message to a specific Java Object model

Modifications:
- Add a new `consumerConfig` flag "useSchema"
- With useSchema=true when we consume data we apply the Schema and return a specific JMS Message depending on the schema type

Supported Schemas:
In the initial implementation we are supporting:
- String schema: maps to a TextMessage
- AVRO schema: maps to a MapMessage (nested values are working as expected)
- KeyValue schema: maps a MapMessage, in particular KeyValue<AVRO, AVRO> maps to a MapMessage with two entries, 'key' and 'value'

Sample configuration:
```
    Map<String, Object> consumerConfig = new HashMap<>();
    properties.put("consumerConfig", consumerConfig);
    
    Map<String, Object> properties = new HashMap<>();
    properties.put("webServiceUrl", cluster.getAddress());
    consumerConfig.put("useSchema", true);
```