### PR TITLE
Make PulsarConnectionFactory Serializable

### DIFF
--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -97,8 +97,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -108,8 +108,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
@@ -15,9 +15,14 @@
  */
 package com.datastax.oss.pulsar.jms;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import javax.jms.IllegalStateException;
 import javax.jms.IllegalStateRuntimeException;
 import javax.jms.InvalidClientIDException;
@@ -284,5 +289,41 @@ public final class Utils {
     JMSRuntimeException jms = new JMSRuntimeException("Generic error " + err.getMessage());
     jms.initCause(err);
     throw jms;
+  }
+
+  private static List deepCopyList(List configuration) {
+    return (List) configuration.stream().map(f -> deepCopyObject(f)).collect(Collectors.toList());
+  }
+
+  private static Set deepCopySet(Set configuration) {
+    return (Set) configuration.stream().map(f -> deepCopyObject(f)).collect(Collectors.toSet());
+  }
+
+  public static Object deepCopyObject(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Map) {
+      return deepCopyMap((Map) value);
+    }
+    if (value instanceof List) {
+      return deepCopyList((List) value);
+    }
+    if (value instanceof Set) {
+      return deepCopySet((Set) value);
+    }
+    return value;
+  }
+
+  public static Map<String, Object> deepCopyMap(Map<String, Object> configuration) {
+    if (configuration == null) {
+      return null;
+    }
+    Map<String, Object> copy = new HashMap<>();
+    configuration.forEach(
+        (key, value) -> {
+          copy.put(key, deepCopyObject(value));
+        });
+    return copy;
   }
 }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
@@ -183,12 +183,11 @@ public class PulsarInteropTest {
         Destination destination = context.createTopic(topic);
 
         PulsarClient client =
-                cluster
-                        .getService()
-                        .getClient(); // do not close this client, it is internal to the broker
+            cluster
+                .getService()
+                .getClient(); // do not close this client, it is internal to the broker
         try (JMSConsumer consumer = context.createConsumer(destination)) {
-          try (Producer<Long> producer =
-                       client.newProducer(Schema.INT64).topic(topic).create(); ) {
+          try (Producer<Long> producer = client.newProducer(Schema.INT64).topic(topic).create(); ) {
             producer.newMessage().value(23432424L).key("bar").send();
 
             // the JMS client reads Schema INT64 as ObjectMessage

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SerializableConnectionFactoryTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SerializableConnectionFactoryTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Slf4j
+public class SerializableConnectionFactoryTest {
+  @TempDir public static Path tempDir;
+  private static PulsarCluster cluster;
+
+  @BeforeAll
+  public static void before() throws Exception {
+    cluster = new PulsarCluster(tempDir, true, false);
+    cluster.start();
+  }
+
+  @AfterAll
+  public static void after() throws Exception {
+    if (cluster != null) {
+      cluster.close();
+    }
+  }
+
+  @Test
+  public void test() throws Exception {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+
+    try (PulsarConnectionFactory factory1 = new PulsarConnectionFactory(properties);
+        PulsarConnectionFactory factory2 = new PulsarConnectionFactory(properties); ) {
+
+      ConnectionFactory[] array = new ConnectionFactory[] {factory1, factory2};
+
+      try (Connection connection1 = factory1.createConnection();
+          Connection connection2 = factory2.createConnection();
+          Session session1 = connection1.createSession(Session.AUTO_ACKNOWLEDGE);
+          Session session2 = connection2.createSession(Session.AUTO_ACKNOWLEDGE)) {
+
+        // use the factories, to produce and consume
+        Queue queue = session1.createQueue("test");
+
+        Queue queue2 = session1.createQueue("test2");
+
+        session1.createProducer(queue).send(session1.createTextMessage("foo0"));
+        session1.createProducer(queue).send(session1.createTextMessage("foo1"));
+        session1.createProducer(queue).send(session1.createTextMessage("foo2"));
+
+        try (MessageConsumer consumer = session2.createConsumer(queue)) {
+          connection2.start();
+          assertEquals("foo0", consumer.receive().getBody(String.class));
+        }
+
+        // serialise
+        byte[] serialised = serializeObject(array);
+
+        // deserialize
+        ConnectionFactory[] array2 = (ConnectionFactory[]) deserializeObject(serialised);
+
+        // verify that the connections work
+        int i = 1;
+
+        assertEquals(2, array2.length);
+        for (int j = 0; i < array2.length; j++) {
+          ConnectionFactory factory = array2[j];
+          try (Connection con = factory.createConnection();
+              Session session = con.createSession(Session.AUTO_ACKNOWLEDGE);
+              MessageConsumer consumer = session.createConsumer(queue); ) {
+            con.start();
+
+            // consume from previously created Queue
+            assertEquals("foo" + i, consumer.receive().getBody(String.class));
+            i++;
+
+            // use the Pulsar Producer
+            try (MessageProducer producer = session.createProducer(queue2); ) {
+              producer.send(session.createTextMessage("bar"));
+            }
+
+            // use Pulsar Consumer
+            try (MessageConsumer consumer2 = session.createConsumer(queue2); ) {
+              assertEquals("bar", consumer2.receive().getBody(String.class));
+            }
+          }
+
+          // dispose
+          ((PulsarConnectionFactory) factory).close();
+        }
+      }
+    }
+  }
+
+  private static Object deserializeObject(byte[] serialised) throws Exception {
+    try (ByteArrayInputStream in = new ByteArrayInputStream(serialised);
+        ObjectInputStream ii = new ObjectInputStream(in)) {
+      return ii.readObject();
+    }
+  }
+
+  private static byte[] serializeObject(Object object) throws Exception {
+    byte[] serialised;
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ObjectOutputStream oo = new ObjectOutputStream(out); ) {
+      oo.writeObject(object);
+      oo.flush();
+      serialised = out.toByteArray();
+    }
+    return serialised;
+  }
+}


### PR DESCRIPTION
Modifications:
- make PulsarConnectionFactory Serializable
- ensure that we do not modify the 'configuration' during initialisation
- implement writeObject/readObject
- add some reflection tricks to handle a bunch of final fields during readObject
- add test cases


The serialised version of a PulsarConnectionFactory is the JSON representation of the Configuration