### PR TITLE
Feature: add support for DeadLetterQueue configuration

### DIFF
--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -97,8 +97,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -657,11 +657,8 @@ public class PulsarConnectionFactory
     if (useCredentialsFromCreateConnection) {
       validateConnectUsernamePasswordReused(userName, password);
     }
-
-    if (!anonymous
-            && tckUsername != null && !tckUsername.isEmpty()) {
-      if (!Objects.equals(tckUsername, userName)
-              || !Objects.equals(tckPassword, password)) {
+    if (!anonymous && tckUsername != null && !tckUsername.isEmpty()) {
+      if (!Objects.equals(tckUsername, userName) || !Objects.equals(tckPassword, password)) {
         // this verification is here only for the TCK
         throw new JMSSecurityException("Unauthorized");
       }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.client.api.BatcherBuilder;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
@@ -56,10 +57,12 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
 
@@ -92,6 +95,9 @@ public class PulsarConnectionFactory
   private transient Map<String, Object> producerConfiguration;
   private transient Map<String, Object> consumerConfiguration;
   private transient Schema<?> consumerSchema;
+  private transient DeadLetterPolicy deadLetterPolicy;
+  private transient RedeliveryBackoff negativeAckRedeliveryBackoff;
+  private transient RedeliveryBackoff ackTimeoutRedeliveryBackoff;
   private transient String systemNamespace = "public/default";
   private transient String defaultClientId = null;
   private transient boolean enableTransaction = false;
@@ -254,6 +260,13 @@ public class PulsarConnectionFactory
         if (useSchema) {
           consumerSchema = Schema.AUTO_CONSUME();
         }
+
+        deadLetterPolicy = getAndRemoveDeadLetterPolicy(consumerConfiguration);
+        negativeAckRedeliveryBackoff =
+            getAndRemoveRedeliveryBackoff("negativeAckRedeliveryBackoff", consumerConfiguration);
+        ackTimeoutRedeliveryBackoff =
+            getAndRemoveRedeliveryBackoff("ackTimeoutRedeliveryBackoff", consumerConfiguration);
+
       } else {
         this.consumerConfiguration = Collections.emptyMap();
       }
@@ -469,6 +482,68 @@ public class PulsarConnectionFactory
     } catch (Throwable t) {
       throw Utils.handleException(t);
     }
+  }
+
+  private static RedeliveryBackoff getAndRemoveRedeliveryBackoff(
+      String baseName, Map<String, Object> consumerConfiguration) {
+    Map<String, Object> config = (Map<String, Object>) consumerConfiguration.remove(baseName);
+    if (config == null) {
+      return null;
+    }
+    MultiplierRedeliveryBackoff.MultiplierRedeliveryBackoffBuilder builder =
+        MultiplierRedeliveryBackoff.builder();
+    long maxDelayMs = Long.parseLong(getAndRemoveString("maxDelayMs", "-1", config));
+    if (maxDelayMs >= 0) {
+      builder.maxDelayMs(maxDelayMs);
+    }
+
+    long minDelayMs = Long.parseLong(getAndRemoveString("minDelayMs", "-1", config));
+    if (minDelayMs >= 0) {
+      builder.minDelayMs(minDelayMs);
+    }
+    double multiplier = Double.parseDouble(getAndRemoveString("multiplier", "-1", config));
+    if (multiplier >= 0) {
+      builder.multiplier(multiplier);
+    }
+    if (!config.isEmpty()) {
+      throw new IllegalArgumentException("Unhandled fields in " + baseName + ": " + config);
+    }
+    return builder.build();
+  }
+
+  private static DeadLetterPolicy getAndRemoveDeadLetterPolicy(
+      Map<String, Object> consumerConfiguration) {
+    Map<String, Object> deadLetterPolicyConfig =
+        (Map<String, Object>) consumerConfiguration.remove("deadLetterPolicy");
+    if (deadLetterPolicyConfig == null || deadLetterPolicyConfig.isEmpty()) {
+      return null;
+    }
+
+    DeadLetterPolicy.DeadLetterPolicyBuilder deadLetterPolicyBuilder = DeadLetterPolicy.builder();
+    String deadLetterTopic = getAndRemoveString("deadLetterTopic", "", deadLetterPolicyConfig);
+    if (!deadLetterTopic.isEmpty()) {
+      deadLetterPolicyBuilder.deadLetterTopic(deadLetterTopic);
+    }
+    String retryLetterTopic = getAndRemoveString("retryLetterTopic", "", deadLetterPolicyConfig);
+    if (!deadLetterTopic.isEmpty()) {
+      deadLetterPolicyBuilder.retryLetterTopic(retryLetterTopic);
+    }
+    String initialSubscriptionName =
+        getAndRemoveString("initialSubscriptionName", "", deadLetterPolicyConfig);
+    if (!initialSubscriptionName.isEmpty()) {
+      deadLetterPolicyBuilder.initialSubscriptionName(initialSubscriptionName);
+    }
+    int maxRedeliverCount =
+        Integer.parseInt(getAndRemoveString("maxRedeliverCount", "-1", deadLetterPolicyConfig));
+    if (maxRedeliverCount > -1) {
+      deadLetterPolicyBuilder.maxRedeliverCount(maxRedeliverCount);
+    }
+    if (!deadLetterPolicyConfig.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Unhandled fields in deadLetterPolicy: " + deadLetterPolicyConfig);
+    }
+
+    return deadLetterPolicyBuilder.build();
   }
 
   private void validateConnectUsernamePasswordReused(String connectUsername, String connectPassword)
@@ -1144,6 +1219,15 @@ public class PulsarConnectionFactory
               .subscriptionType(subscriptionType)
               .subscriptionName(subscriptionName)
               .topic(fullQualifiedTopicName);
+      if (deadLetterPolicy != null) {
+        builder.deadLetterPolicy(deadLetterPolicy);
+      }
+      if (negativeAckRedeliveryBackoff != null) {
+        builder.negativeAckRedeliveryBackoff(negativeAckRedeliveryBackoff);
+      }
+      if (ackTimeoutRedeliveryBackoff != null) {
+        builder.ackTimeoutRedeliveryBackoff(ackTimeoutRedeliveryBackoff);
+      }
       Consumer<?> newConsumer = builder.subscribe();
       consumers.add(newConsumer);
 

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/DeadLetterQueueTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/DeadLetterQueueTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.Topic;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Slf4j
+public class DeadLetterQueueTest {
+
+  @TempDir public static Path tempDir;
+  private static PulsarCluster cluster;
+
+  @BeforeAll
+  public static void before() throws Exception {
+    cluster = new PulsarCluster(tempDir, config -> config.setTransactionCoordinatorEnabled(false));
+    cluster.start();
+  }
+
+  @AfterAll
+  public static void after() throws Exception {
+    if (cluster != null) {
+      cluster.close();
+    }
+  }
+
+  @Test
+  public void deadLetterTest() throws Exception {
+
+    // basic test
+    String topic = "persistent://public/default/test-" + UUID.randomUUID();
+    // this name is automatic, but you can configure it
+    // https://pulsar.apache.org/docs/concepts-messaging/#dead-letter-topic
+    String queueSubscriptionName = "thesub";
+    String deadLetterTopic = topic + "-" + queueSubscriptionName + "-DLQ";
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.queueSubscriptionName", queueSubscriptionName);
+
+    Map<String, Object> consumerConfig = new HashMap<>();
+    properties.put("consumerConfig", consumerConfig);
+
+    consumerConfig.put("ackTimeoutMillis", 1000);
+
+    Map<String, Object> deadLetterPolicy = new HashMap<>();
+    consumerConfig.put("deadLetterPolicy", deadLetterPolicy);
+    deadLetterPolicy.put("maxRedeliverCount", 1);
+    // this is the name of a subscription that is created
+    // while creating the producer to the DQL topic
+    deadLetterPolicy.put("initialSubscriptionName", "dqlsub");
+
+    performTest(topic, deadLetterTopic, properties);
+  }
+
+  @Test
+  public void deadLetterConfigTest() throws Exception {
+
+    // in this test we try to set al possible configuration value
+
+    String topic = "persistent://public/default/test-" + UUID.randomUUID();
+    String deadLetterTopic = "persistent://public/default/test-dlq-" + UUID.randomUUID();
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+
+    Map<String, Object> consumerConfig = new HashMap<>();
+    properties.put("consumerConfig", consumerConfig);
+
+    consumerConfig.put("ackTimeoutMillis", 1000);
+
+    Map<String, Object> deadLetterPolicy = new HashMap<>();
+    consumerConfig.put("deadLetterPolicy", deadLetterPolicy);
+    deadLetterPolicy.put("maxRedeliverCount", 1);
+    deadLetterPolicy.put("deadLetterTopic", deadLetterTopic);
+    deadLetterPolicy.put("initialSubscriptionName", "dqlsub");
+
+    Map<String, Object> negativeAckRedeliveryBackoff = new HashMap<>();
+    consumerConfig.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
+    negativeAckRedeliveryBackoff.put("minDelayMs", 10);
+    negativeAckRedeliveryBackoff.put("maxDelayMs", 100);
+    negativeAckRedeliveryBackoff.put("multiplier", 2.0);
+
+    Map<String, Object> ackTimeoutRedeliveryBackoff = new HashMap<>();
+    consumerConfig.put("ackTimeoutRedeliveryBackoff", ackTimeoutRedeliveryBackoff);
+    ackTimeoutRedeliveryBackoff.put("minDelayMs", 10);
+    ackTimeoutRedeliveryBackoff.put("maxDelayMs", 100);
+    ackTimeoutRedeliveryBackoff.put("multiplier", 2.0);
+
+    performTest(topic, deadLetterTopic, properties);
+  }
+
+  private void performTest(String topic, String deadLetterTopic, Map<String, Object> properties)
+      throws JMSException {
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (Connection connection = factory.createConnection()) {
+        connection.start();
+        try (Session session = connection.createSession(Session.CLIENT_ACKNOWLEDGE); ) {
+          Queue destination = session.createQueue(topic);
+
+          try (MessageProducer producer = session.createProducer(destination); ) {
+            producer.send(session.createTextMessage("foo"));
+          }
+
+          try (MessageConsumer consumer1 = session.createConsumer(destination); ) {
+
+            Message message = consumer1.receive();
+            assertEquals("foo", message.getBody(String.class));
+            assertEquals(1, message.getIntProperty("JMSXDeliveryCount"));
+            assertFalse(message.getJMSRedelivered());
+
+            // message is re-delivered again after ackTimeoutMillis
+            message = consumer1.receive();
+            assertEquals("foo", message.getBody(String.class));
+            assertEquals(2, message.getIntProperty("JMSXDeliveryCount"));
+            assertTrue(message.getJMSRedelivered());
+
+            Topic destinationDeadletter = session.createTopic(deadLetterTopic);
+
+            try (MessageConsumer consumerDeadLetter =
+                session.createSharedConsumer(destinationDeadletter, "dqlsub"); ) {
+
+              message = consumerDeadLetter.receive();
+              assertEquals("foo", message.getBody(String.class));
+              log.info("DLQ MESSAGE {}", message);
+              // this is another topic, and the JMSXDeliveryCount is only handled on the client side
+              // so the count is back to 1
+              assertEquals(1, message.getIntProperty("JMSXDeliveryCount"));
+              assertFalse(message.getJMSRedelivered());
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
@@ -554,6 +554,7 @@ public class SimpleTest {
         fail();
       } catch (JMSSecurityException ok) {
       }
+
       try (JMSContext connection = factory.createContext(null, null, JMSContext.AUTO_ACKNOWLEDGE)) {
         fail();
       } catch (JMSSecurityRuntimeException ok) {


### PR DESCRIPTION
Allow to configure DeadLetterPolicy

See here for reference
https://pulsar.apache.org/docs/concepts-messaging/#dead-letter-topic

New configuration:
- ackTimeoutMillis: this is as "ackTimeout" on the ConsumerConfiguration in the PulsarClient, but expressed in milliseconds
- deadLetterPolicy: this is to configure the "DeadLetterPolicy" in the consumer, valid fields:
 -- deadLetterTopic: the name of the dead letter topic (if not set it is automatically set by the PulsarClient, according to the docs of the PulsarClient
 -- initialSubscriptionName: the name of an initial subscription created on the deadLetterTopic while producing the first message (see Pulsar docs)
 -- maxRedeliverCount: the maximum number of deliveries of a message, please refer to the Pulsar Client docs
* negativeAckRedeliveryBackoff: configuration for the negativeAckRedeliveryBackoff (see Pulsar Docs), allowed fields:
 -- minDelayMs
 -- maxDelayMs
 -- multiplier
* ackTimeoutRedeliveryBackoff:  configuration for the ackTimeoutRedeliveryBackoff (see Pulsar Docs), allowed fields:
 -- minDelayMs
 -- maxDelayMs
 -- multiplier


In order to trigger writes to the DLQ the Pulsar client has two ways:
- ackTimeout -> the messages isn't acknowledged within a specific amount of time
- negative acknoledgedment

Startlight for JMS uses negative acknoledgment in some cases:

When you call Session.recover() explicitly: 
In this case the JMS application requests explicitly to re-deliver the messages (https://github.com/datastax/pulsar-jms/blob/5a82e0e03c20cad02a84325907c951e9ffca9f3a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java#L561)

When you use JMS Selectors:

When you are using "Client side emulation" and a message does not match the Selector, then the JMS Client negatively acknowledges the message to let another consume pick up the message.  This happens only for JMS Queues and for Shared Subscriptions.

If you are using Server Side Filtering there is still a chance that a negative acknowledge is sent: when you receive a batch of messages, and one message does not match the filter.

Using negative acknowledgement increases the count of deliveries of the message, and that it the trigger (see maxRedeliverCount) to send a message to the DQL.

So when you are using Selectors there is a chance that your messages are sent to the DLQ because they hit too many times a Consumer whose local selector does not match the message.


