### PR TITLE
Filter: make it work without a Consumer (for backlog calculation)

### DIFF
--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -128,6 +128,12 @@ public class JMSFilter implements EntryFilter {
     }
 
     CommandSubscribe.SubType subType = subscription.getType();
+    if (subType == null) {
+      // this is possible during backlog calculation if the dispatcher has not
+      // been created yet, so no consumer ever connected and the type of
+      // subscription is not known yet
+      subType = CommandSubscribe.SubType.Shared;
+    }
     final boolean isExclusive;
     switch (subType) {
       case Exclusive:

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -18,6 +18,7 @@ package com.datastax.oss.pulsar.jms.selectors;
 import io.netty.buffer.ByteBuf;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,7 +52,8 @@ public class JMSFilter implements EntryFilter {
   @Override
   public FilterResult filterEntry(Entry entry, FilterContext context) {
     Consumer consumer = context.getConsumer();
-    Map<String, String> consumerMetadata = consumer.getMetadata();
+    Map<String, String> consumerMetadata =
+        consumer != null ? consumer.getMetadata() : Collections.emptyMap();
     Subscription subscription = context.getSubscription();
     boolean jmsFiltering = "true".equals(consumerMetadata.get("jms.filtering"));
     final String jmsSelectorOnSubscription;
@@ -125,7 +127,7 @@ public class JMSFilter implements EntryFilter {
       return FilterResult.RESCHEDULE;
     }
 
-    CommandSubscribe.SubType subType = consumer.subType();
+    CommandSubscribe.SubType subType = subscription.getType();
     final boolean isExclusive;
     switch (subType) {
       case Exclusive:


### PR DESCRIPTION
During backlog calculation there is no "Consumer" and sometime the "Subscription type" is unknown, because the "Subscription type" is decided when the first consumer connects (this happen at every topic "load", not only the first time in the subscription life)

We have to handle those cases:
- we assume empty selector for the consumer and default options
- we assume a "shared" subscription (default option for Queues)