### PR TITLE
Fix behaviour of acknowledgeRejectedMessages with Server Side Filters

### DIFF
--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -82,8 +82,9 @@ public class JMSFilter implements EntryFilter {
     boolean forceDropRejected =
         "true".equals(consumerMetadata.getOrDefault("jms.force.drop.rejected", "false"));
     final FilterResult rejectResultForSelector;
-    if ("drop".equals(jmsSelectorRejectAction)) {
+    if ("drop".equals(jmsSelectorRejectAction) || forceDropRejected) {
       // this is the common behaviour for a Topics
+      // or happens for Queues with jms.acknowledgeRejectedMessages=true
       rejectResultForSelector = FilterResult.REJECT;
     } else {
       // this is the common behaviour for a Queue

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -346,7 +346,7 @@ public class PulsarConnectionFactory
                   "jms.useExclusiveSubscriptionsForSimpleConsumers", "true", configurationCopy));
 
       // This flag is to force acknowledgement for messages that are rejected due to
-      // client side filtering in case of Shared subscription.
+      // filtering in case of Shared subscription.
       // If you have a shared subscription on a topic (Topic or Queue) and a message
       // is filtered out, by default we negatively acknowledge the message in order to
       // let another consumer on the same subscription to receive it.


### PR DESCRIPTION
Problem:
jms.acknowledgeRejectedMessages does not play well with server side filters in case of messages filtered out by a selector (if works in other cases)

Modifications:
use the flag on the server side filters when the message is dropped due to a selector