### PR TITLE
[feature] add the ability to override the ConsumerConfiguration per Session/JMSContext

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/ConsumerConfiguration.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/ConsumerConfiguration.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static com.datastax.oss.pulsar.jms.Utils.getAndRemoveString;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
+
+final class ConsumerConfiguration {
+
+  static ConsumerConfiguration DEFAULT =
+      new ConsumerConfiguration(Collections.emptyMap(), null, null, null, null);
+
+  private final Map<String, Object> consumerConfiguration;
+  private Schema<?> consumerSchema;
+  private DeadLetterPolicy deadLetterPolicy;
+  private RedeliveryBackoff negativeAckRedeliveryBackoff;
+  private RedeliveryBackoff ackTimeoutRedeliveryBackoff;
+
+  ConsumerConfiguration(
+      Map<String, Object> consumerConfiguration,
+      Schema<?> consumerSchema,
+      DeadLetterPolicy deadLetterPolicy,
+      RedeliveryBackoff negativeAckRedeliveryBackoff,
+      RedeliveryBackoff ackTimeoutRedeliveryBackoff) {
+    this.consumerConfiguration = Objects.requireNonNull(consumerConfiguration);
+    this.consumerSchema = consumerSchema;
+    this.deadLetterPolicy = deadLetterPolicy;
+    this.negativeAckRedeliveryBackoff = negativeAckRedeliveryBackoff;
+    this.ackTimeoutRedeliveryBackoff = ackTimeoutRedeliveryBackoff;
+  }
+
+  public Map<String, Object> getConsumerConfiguration() {
+    return consumerConfiguration;
+  }
+
+  public Schema<?> getConsumerSchema() {
+    return consumerSchema;
+  }
+
+  public DeadLetterPolicy getDeadLetterPolicy() {
+    return deadLetterPolicy;
+  }
+
+  public RedeliveryBackoff getNegativeAckRedeliveryBackoff() {
+    return negativeAckRedeliveryBackoff;
+  }
+
+  public RedeliveryBackoff getAckTimeoutRedeliveryBackoff() {
+    return ackTimeoutRedeliveryBackoff;
+  }
+
+  ConsumerConfiguration applyDefaults(ConsumerConfiguration defaultConsumerConfiguration) {
+    Map<String, Object> mergedConsumerConfiguration = new HashMap<>();
+    if (defaultConsumerConfiguration.consumerConfiguration != null) {
+      mergedConsumerConfiguration.putAll(
+          Utils.deepCopyMap(defaultConsumerConfiguration.consumerConfiguration));
+    }
+    if (consumerConfiguration != null) {
+      mergedConsumerConfiguration.putAll(Utils.deepCopyMap(consumerConfiguration));
+    }
+    Schema<?> mergedConsumerSchema =
+        consumerSchema != null ? consumerSchema : defaultConsumerConfiguration.consumerSchema;
+    DeadLetterPolicy mergedDeadLetterPolicy =
+        deadLetterPolicy != null ? deadLetterPolicy : defaultConsumerConfiguration.deadLetterPolicy;
+    RedeliveryBackoff mergedNegativeAckRedeliveryBackoff =
+        negativeAckRedeliveryBackoff != null
+            ? negativeAckRedeliveryBackoff
+            : defaultConsumerConfiguration.negativeAckRedeliveryBackoff;
+    RedeliveryBackoff mergedAckTimeoutRedeliveryBackoff =
+        ackTimeoutRedeliveryBackoff != null
+            ? ackTimeoutRedeliveryBackoff
+            : defaultConsumerConfiguration.ackTimeoutRedeliveryBackoff;
+
+    return new ConsumerConfiguration(
+        mergedConsumerConfiguration,
+        mergedConsumerSchema,
+        mergedDeadLetterPolicy,
+        mergedNegativeAckRedeliveryBackoff,
+        mergedAckTimeoutRedeliveryBackoff);
+  }
+
+  static ConsumerConfiguration buildConsumerConfiguration(
+      Map<String, Object> consumerConfigurationM) {
+    if (consumerConfigurationM == null || consumerConfigurationM.isEmpty()) {
+      return DEFAULT;
+    }
+    consumerConfigurationM = Utils.deepCopyMap(consumerConfigurationM);
+
+    Schema<?> consumerSchema = null;
+    Map<String, Object> consumerConfiguration = Collections.emptyMap();
+    DeadLetterPolicy deadLetterPolicy = null;
+    RedeliveryBackoff negativeAckRedeliveryBackoff = null;
+    RedeliveryBackoff ackTimeoutRedeliveryBackoff = null;
+
+    if (consumerConfigurationM != null) {
+      consumerConfiguration = new HashMap(consumerConfigurationM);
+
+      // remove values that cannot be accepted by loadConf()
+      if (consumerConfiguration.containsKey("useSchema")) {
+        boolean useSchema =
+            Boolean.parseBoolean(getAndRemoveString("useSchema", "false", consumerConfiguration));
+        if (useSchema) {
+          consumerSchema = Schema.AUTO_CONSUME();
+        } else {
+          consumerSchema = Schema.BYTES;
+        }
+      }
+
+      deadLetterPolicy = getAndRemoveDeadLetterPolicy(consumerConfiguration);
+      negativeAckRedeliveryBackoff =
+          getAndRemoveRedeliveryBackoff("negativeAckRedeliveryBackoff", consumerConfiguration);
+      ackTimeoutRedeliveryBackoff =
+          getAndRemoveRedeliveryBackoff("ackTimeoutRedeliveryBackoff", consumerConfiguration);
+    }
+    return new ConsumerConfiguration(
+        consumerConfiguration,
+        consumerSchema,
+        deadLetterPolicy,
+        negativeAckRedeliveryBackoff,
+        ackTimeoutRedeliveryBackoff);
+  }
+
+  private static RedeliveryBackoff getAndRemoveRedeliveryBackoff(
+      String baseName, Map<String, Object> consumerConfiguration) {
+    Map<String, Object> config = (Map<String, Object>) consumerConfiguration.remove(baseName);
+    if (config == null) {
+      return null;
+    }
+    MultiplierRedeliveryBackoff.MultiplierRedeliveryBackoffBuilder builder =
+        MultiplierRedeliveryBackoff.builder();
+    long maxDelayMs = Long.parseLong(getAndRemoveString("maxDelayMs", "-1", config));
+    if (maxDelayMs >= 0) {
+      builder.maxDelayMs(maxDelayMs);
+    }
+
+    long minDelayMs = Long.parseLong(getAndRemoveString("minDelayMs", "-1", config));
+    if (minDelayMs >= 0) {
+      builder.minDelayMs(minDelayMs);
+    }
+    double multiplier = Double.parseDouble(getAndRemoveString("multiplier", "-1", config));
+    if (multiplier >= 0) {
+      builder.multiplier(multiplier);
+    }
+    if (!config.isEmpty()) {
+      throw new IllegalArgumentException("Unhandled fields in " + baseName + ": " + config);
+    }
+    return builder.build();
+  }
+
+  private static DeadLetterPolicy getAndRemoveDeadLetterPolicy(
+      Map<String, Object> consumerConfiguration) {
+    Map<String, Object> deadLetterPolicyConfig =
+        (Map<String, Object>) consumerConfiguration.remove("deadLetterPolicy");
+    if (deadLetterPolicyConfig == null || deadLetterPolicyConfig.isEmpty()) {
+      return null;
+    }
+
+    DeadLetterPolicy.DeadLetterPolicyBuilder deadLetterPolicyBuilder = DeadLetterPolicy.builder();
+    String deadLetterTopic = getAndRemoveString("deadLetterTopic", "", deadLetterPolicyConfig);
+    if (!deadLetterTopic.isEmpty()) {
+      deadLetterPolicyBuilder.deadLetterTopic(deadLetterTopic);
+    }
+    String retryLetterTopic = getAndRemoveString("retryLetterTopic", "", deadLetterPolicyConfig);
+    if (!deadLetterTopic.isEmpty()) {
+      deadLetterPolicyBuilder.retryLetterTopic(retryLetterTopic);
+    }
+    String initialSubscriptionName =
+        getAndRemoveString("initialSubscriptionName", "", deadLetterPolicyConfig);
+    if (!initialSubscriptionName.isEmpty()) {
+      deadLetterPolicyBuilder.initialSubscriptionName(initialSubscriptionName);
+    }
+    int maxRedeliverCount =
+        Integer.parseInt(getAndRemoveString("maxRedeliverCount", "-1", deadLetterPolicyConfig));
+    if (maxRedeliverCount > -1) {
+      deadLetterPolicyBuilder.maxRedeliverCount(maxRedeliverCount);
+    }
+    if (!deadLetterPolicyConfig.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Unhandled fields in deadLetterPolicy: " + deadLetterPolicyConfig);
+    }
+
+    return deadLetterPolicyBuilder.build();
+  }
+}

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
@@ -167,10 +167,19 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
    */
   @Override
   public PulsarSession createSession(boolean transacted, int acknowledgeMode) throws JMSException {
+    return createSession(transacted, acknowledgeMode, null);
+  }
+
+  PulsarSession createSession(
+      boolean transacted, int acknowledgeMode, ConsumerConfiguration overrideconsumerConfiguration)
+      throws JMSException {
     checkNotClosed();
     allowSetClientId = false;
     PulsarSession session =
-        new PulsarSession(transacted ? Session.SESSION_TRANSACTED : acknowledgeMode, this);
+        new PulsarSession(
+            transacted ? Session.SESSION_TRANSACTED : acknowledgeMode,
+            this,
+            overrideconsumerConfiguration);
     sessions.add(session);
     return session;
   }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -627,7 +627,7 @@ public class PulsarConnectionFactory
    * @since JMS 2.0
    */
   @Override
-  public PulsarJMSContext createContext() {
+  public JMSContext createContext() {
     return createContext(JMSContext.AUTO_ACKNOWLEDGE);
   }
 
@@ -853,7 +853,7 @@ public class PulsarConnectionFactory
    * @since JMS 2.0
    */
   @Override
-  public PulsarJMSContext createContext(int sessionMode) {
+  public JMSContext createContext(int sessionMode) {
     Utils.runtimeException(() -> ensureInitialized(null, null));
     Utils.runtimeException(() -> validateUserNamePassword(true, null, null));
     return new PulsarJMSContext(this, sessionMode, true, null, null);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -144,6 +144,7 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
                   currentSelector,
                   noLocal,
                   session.getConnection().getConnectionId(),
+                  session.getOverrideConsumerConfiguration(),
                   selectorOnSubscriptionReceiver);
       String jmsSelectorOnSubscription = selectorOnSubscriptionReceiver.get();
       if (jmsSelectorOnSubscription != null && !jmsSelectorOnSubscription.isEmpty()) {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
@@ -38,7 +38,10 @@ final class PulsarQueueBrowser implements QueueBrowser {
     session.checkNotClosed();
     this.session = session;
     this.queue = (PulsarQueue) queue;
-    this.reader = session.getFactory().createReaderForBrowser(this.queue);
+    this.reader =
+        session
+            .getFactory()
+            .createReaderForBrowser(this.queue, session.getOverrideConsumerConfiguration());
     // we are reading messages and it is always safe to apply selectors
     // on the client side
     this.selectorSupport = SelectorSupport.build(selector, true);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
@@ -326,4 +326,10 @@ public final class Utils {
         });
     return copy;
   }
+
+  public static String getAndRemoveString(
+      String name, String defaultValue, Map<String, Object> properties) {
+    Object value = (Object) properties.remove(name);
+    return value != null ? value.toString() : defaultValue;
+  }
 }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConsumerConfigurationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConsumerConfigurationTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.jupiter.api.Test;
+
+final class ConsumerConfigurationTest {
+
+  private void test(
+      Map<String, Object> consumerConfiguration, Consumer<ConsumerConfiguration> test) {
+    test(consumerConfiguration, ConsumerConfiguration.DEFAULT, test);
+  }
+
+  private void test(
+      Map<String, Object> consumerConfiguration,
+      ConsumerConfiguration defaultConfiguration,
+      Consumer<ConsumerConfiguration> test) {
+    ConsumerConfiguration result =
+        ConsumerConfiguration.buildConsumerConfiguration(consumerConfiguration);
+
+    // test that the ConsumerConfiguration matches the provided configuration
+    test.accept(result);
+
+    // test that the provided configuration applies also when applied to the default configuration
+    test.accept(result.applyDefaults(defaultConfiguration));
+  }
+
+  @Test
+  void testBuildEmptyConfiguration() {
+    Map<String, Object> consumerConfiguration = new HashMap<>();
+    test(
+        consumerConfiguration,
+        (result -> {
+          assertTrue(result.getConsumerConfiguration().isEmpty());
+          assertNull(result.getAckTimeoutRedeliveryBackoff());
+          assertNull(result.getNegativeAckRedeliveryBackoff());
+          assertNull(result.getDeadLetterPolicy());
+          assertNull(result.getConsumerSchema());
+        }));
+  }
+
+  @Test
+  void testOverrideComplexConfiguration() {
+
+    Map<String, Object> defaultConfiguration = new HashMap<>();
+    defaultConfiguration.put("useSchema", true);
+    defaultConfiguration.put("ackTimeoutMillis", 1234L);
+    Map<String, Object> deadLetterPolicy = new HashMap<>();
+    defaultConfiguration.put("deadLetterPolicy", deadLetterPolicy);
+    deadLetterPolicy.put("maxRedeliverCount", 5);
+    deadLetterPolicy.put("deadLetterTopic", "dql-topic-default");
+    deadLetterPolicy.put("initialSubscriptionName", "dqlsub-default");
+
+    Map<String, Object> negativeAckRedeliveryBackoff = new HashMap<>();
+    defaultConfiguration.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
+    negativeAckRedeliveryBackoff.put("minDelayMs", 10);
+    negativeAckRedeliveryBackoff.put("maxDelayMs", 100);
+    negativeAckRedeliveryBackoff.put("multiplier", 2.0);
+
+    Map<String, Object> ackTimeoutRedeliveryBackoff = new HashMap<>();
+    defaultConfiguration.put("ackTimeoutRedeliveryBackoff", ackTimeoutRedeliveryBackoff);
+    ackTimeoutRedeliveryBackoff.put("minDelayMs", 10);
+    ackTimeoutRedeliveryBackoff.put("maxDelayMs", 100);
+    ackTimeoutRedeliveryBackoff.put("multiplier", 2.0);
+
+    test(
+        defaultConfiguration,
+        (result) -> {
+          assertFalse(result.getConsumerConfiguration().isEmpty());
+          assertNotNull(result.getAckTimeoutRedeliveryBackoff());
+          assertNotNull(result.getNegativeAckRedeliveryBackoff());
+          assertNotNull(result.getDeadLetterPolicy());
+          assertNotNull(result.getConsumerSchema());
+        });
+
+    ConsumerConfiguration parsedDefault =
+        ConsumerConfiguration.buildConsumerConfiguration(defaultConfiguration);
+    assertEquals(parsedDefault.getDeadLetterPolicy().getDeadLetterTopic(), "dql-topic-default");
+    assertEquals(parsedDefault.getDeadLetterPolicy().getMaxRedeliverCount(), 5);
+    assertEquals(
+        parsedDefault.getDeadLetterPolicy().getInitialSubscriptionName(), "dqlsub-default");
+    assertEquals(parsedDefault.getConsumerSchema().getClass(), Schema.AUTO_CONSUME().getClass());
+    assertEquals(20, parsedDefault.getNegativeAckRedeliveryBackoff().next(1));
+
+    {
+      // try to override with a empty config
+      Map<String, Object> consumerConfiguration = new HashMap<>();
+
+      ConsumerConfiguration parsedEmpty =
+          ConsumerConfiguration.buildConsumerConfiguration(consumerConfiguration)
+              .applyDefaults(parsedDefault);
+      assertFalse(parsedEmpty.getConsumerConfiguration().isEmpty());
+      assertNotNull(parsedEmpty.getAckTimeoutRedeliveryBackoff());
+      assertNotNull(parsedEmpty.getNegativeAckRedeliveryBackoff());
+      assertNotNull(parsedEmpty.getDeadLetterPolicy());
+      assertEquals(parsedEmpty.getConsumerSchema().getClass(), Schema.AUTO_CONSUME().getClass());
+    }
+
+    {
+      // disable schema
+      Map<String, Object> consumerConfiguration = new HashMap<>();
+      consumerConfiguration.put("useSchema", false);
+
+      ConsumerConfiguration parsedEmpty =
+          ConsumerConfiguration.buildConsumerConfiguration(consumerConfiguration)
+              .applyDefaults(parsedDefault);
+      assertFalse(parsedEmpty.getConsumerConfiguration().isEmpty());
+      assertNotNull(parsedEmpty.getAckTimeoutRedeliveryBackoff());
+      assertNotNull(parsedEmpty.getNegativeAckRedeliveryBackoff());
+      assertNotNull(parsedEmpty.getDeadLetterPolicy());
+      // no more schema
+      assertEquals(parsedEmpty.getConsumerSchema().getSchemaInfo().getType(), SchemaType.BYTES);
+
+      // test can enable schema again
+      Map<String, Object> consumerConfigurationForceEnableSchema = new HashMap<>();
+      consumerConfigurationForceEnableSchema.put("useSchema", true);
+      ConsumerConfiguration enableSchemaAfterDisabled =
+          ConsumerConfiguration.buildConsumerConfiguration(consumerConfigurationForceEnableSchema)
+              .applyDefaults(parsedEmpty);
+      assertEquals(
+          enableSchemaAfterDisabled.getConsumerSchema().getClass(),
+          Schema.AUTO_CONSUME().getClass());
+    }
+
+    {
+      // set a different deadletter policy
+      Map<String, Object> consumerConfiguration = new HashMap<>();
+      Map<String, Object> newDeadLetterPolicy = new HashMap<>();
+      consumerConfiguration.put("deadLetterPolicy", newDeadLetterPolicy);
+      newDeadLetterPolicy.put("maxRedeliverCount", 6);
+      newDeadLetterPolicy.put("deadLetterTopic", "dql-topic-non-default");
+      newDeadLetterPolicy.put("initialSubscriptionName", "dqlsub-non-default");
+
+      ConsumerConfiguration parsedEmpty =
+          ConsumerConfiguration.buildConsumerConfiguration(consumerConfiguration)
+              .applyDefaults(parsedDefault);
+      assertFalse(parsedEmpty.getConsumerConfiguration().isEmpty());
+      assertNotNull(parsedEmpty.getAckTimeoutRedeliveryBackoff());
+      assertNotNull(parsedEmpty.getNegativeAckRedeliveryBackoff());
+      assertEquals(parsedEmpty.getDeadLetterPolicy().getDeadLetterTopic(), "dql-topic-non-default");
+      assertEquals(parsedEmpty.getDeadLetterPolicy().getMaxRedeliverCount(), 6);
+      assertEquals(
+          parsedEmpty.getDeadLetterPolicy().getInitialSubscriptionName(), "dqlsub-non-default");
+      assertEquals(parsedEmpty.getConsumerSchema().getClass(), Schema.AUTO_CONSUME().getClass());
+    }
+
+    {
+      // set a different negativeAckRedeliveryBackoff
+      Map<String, Object> consumerConfiguration = new HashMap<>();
+      Map<String, Object> newNegativeAckRedeliveryBackoff = new HashMap<>();
+      consumerConfiguration.put("negativeAckRedeliveryBackoff", newNegativeAckRedeliveryBackoff);
+      newNegativeAckRedeliveryBackoff.put("minDelayMs", 100);
+      newNegativeAckRedeliveryBackoff.put("maxDelayMs", 100000);
+      newNegativeAckRedeliveryBackoff.put("multiplier", 3.0);
+
+      ConsumerConfiguration parsedEmpty =
+          ConsumerConfiguration.buildConsumerConfiguration(consumerConfiguration)
+              .applyDefaults(parsedDefault);
+      assertFalse(parsedEmpty.getConsumerConfiguration().isEmpty());
+      assertNotNull(parsedEmpty.getAckTimeoutRedeliveryBackoff());
+      assertNotNull(parsedEmpty.getNegativeAckRedeliveryBackoff());
+      assertEquals(300, parsedEmpty.getNegativeAckRedeliveryBackoff().next(1));
+      assertEquals(parsedEmpty.getConsumerSchema().getClass(), Schema.AUTO_CONSUME().getClass());
+    }
+
+    {
+      // set a different negativeAckRedeliveryBackoff
+      Map<String, Object> consumerConfiguration = new HashMap<>();
+      Map<String, Object> newAckTimeoutRedeliveryBackoff = new HashMap<>();
+      consumerConfiguration.put("ackTimeoutRedeliveryBackoff", newAckTimeoutRedeliveryBackoff);
+      newAckTimeoutRedeliveryBackoff.put("minDelayMs", 100);
+      newAckTimeoutRedeliveryBackoff.put("maxDelayMs", 100000);
+      newAckTimeoutRedeliveryBackoff.put("multiplier", 4.0);
+
+      ConsumerConfiguration parsedEmpty =
+          ConsumerConfiguration.buildConsumerConfiguration(consumerConfiguration)
+              .applyDefaults(parsedDefault);
+      assertFalse(parsedEmpty.getConsumerConfiguration().isEmpty());
+      assertNotNull(parsedEmpty.getAckTimeoutRedeliveryBackoff());
+      assertNotNull(parsedEmpty.getNegativeAckRedeliveryBackoff());
+      assertEquals(400, parsedEmpty.getAckTimeoutRedeliveryBackoff().next(1));
+      assertEquals(parsedEmpty.getConsumerSchema().getClass(), Schema.AUTO_CONSUME().getClass());
+    }
+  }
+
+  @Test
+  void testSimpleConfiguration() {
+    Map<String, Object> consumerConfiguration = new HashMap<>();
+    consumerConfiguration.put("ackTimeoutMillis", 100L);
+    test(
+        consumerConfiguration,
+        (result -> {
+          assertEquals(100L, result.getConsumerConfiguration().get("ackTimeoutMillis"));
+          assertNull(result.getAckTimeoutRedeliveryBackoff());
+          assertNull(result.getNegativeAckRedeliveryBackoff());
+          assertNull(result.getDeadLetterPolicy());
+          assertNull(result.getConsumerSchema());
+        }));
+  }
+
+  @Test
+  void testUseSchema() {
+    Map<String, Object> consumerConfiguration = new HashMap<>();
+    consumerConfiguration.put("useSchema", true);
+    test(
+        consumerConfiguration,
+        (result -> {
+          assertNull(result.getAckTimeoutRedeliveryBackoff());
+          assertNull(result.getNegativeAckRedeliveryBackoff());
+          assertNull(result.getDeadLetterPolicy());
+          assertEquals(result.getConsumerSchema().getClass(), Schema.AUTO_CONSUME().getClass());
+        }));
+  }
+
+  @Test
+  void testDeadletterPolicy() {
+    Map<String, Object> consumerConfiguration = new HashMap<>();
+    Map<String, Object> deadLetterPolicy = new HashMap<>();
+    consumerConfiguration.put("deadLetterPolicy", deadLetterPolicy);
+    deadLetterPolicy.put("maxRedeliverCount", 1);
+    deadLetterPolicy.put("deadLetterTopic", "dql-topic");
+    deadLetterPolicy.put("initialSubscriptionName", "dqlsub");
+    test(
+        consumerConfiguration,
+        (result -> {
+          assertNull(result.getAckTimeoutRedeliveryBackoff());
+          assertNull(result.getNegativeAckRedeliveryBackoff());
+          assertNotNull(result.getDeadLetterPolicy());
+          assertEquals(result.getDeadLetterPolicy().getDeadLetterTopic(), "dql-topic");
+          assertEquals(result.getDeadLetterPolicy().getMaxRedeliverCount(), 1);
+          assertEquals(result.getDeadLetterPolicy().getInitialSubscriptionName(), "dqlsub");
+          assertNull(result.getConsumerSchema());
+        }));
+  }
+
+  @Test
+  void testNegativeAckRedeliveryBackoff() {
+    Map<String, Object> consumerConfiguration = new HashMap<>();
+    Map<String, Object> negativeAckRedeliveryBackoff = new HashMap<>();
+    consumerConfiguration.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
+    negativeAckRedeliveryBackoff.put("minDelayMs", 10);
+    negativeAckRedeliveryBackoff.put("maxDelayMs", 100);
+    negativeAckRedeliveryBackoff.put("multiplier", 2.0);
+    test(
+        consumerConfiguration,
+        (result -> {
+          assertNull(result.getAckTimeoutRedeliveryBackoff());
+          assertNotNull(result.getNegativeAckRedeliveryBackoff());
+          assertNull(result.getDeadLetterPolicy());
+          assertNull(result.getConsumerSchema());
+        }));
+  }
+
+  @Test
+  void testAckTimeoutRedeliveryBackoff() {
+    Map<String, Object> consumerConfiguration = new HashMap<>();
+    Map<String, Object> ackTimeoutRedeliveryBackoff = new HashMap<>();
+    consumerConfiguration.put("ackTimeoutRedeliveryBackoff", ackTimeoutRedeliveryBackoff);
+    ackTimeoutRedeliveryBackoff.put("minDelayMs", 10);
+    ackTimeoutRedeliveryBackoff.put("maxDelayMs", 100);
+    ackTimeoutRedeliveryBackoff.put("multiplier", 2.0);
+    test(
+        consumerConfiguration,
+        (result -> {
+          assertNotNull(result.getAckTimeoutRedeliveryBackoff());
+          assertNull(result.getNegativeAckRedeliveryBackoff());
+          assertNull(result.getDeadLetterPolicy());
+          assertNull(result.getConsumerSchema());
+        }));
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/OverrideConsumerConfigurationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/OverrideConsumerConfigurationTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.Topic;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Slf4j
+public class OverrideConsumerConfigurationTest {
+
+  @TempDir public static Path tempDir;
+  private static PulsarCluster cluster;
+
+  @BeforeAll
+  public static void before() throws Exception {
+    cluster =
+        new PulsarCluster(
+            tempDir,
+            (config) -> {
+              config.setTransactionCoordinatorEnabled(false);
+            });
+    cluster.start();
+  }
+
+  @AfterAll
+  public static void after() throws Exception {
+    if (cluster != null) {
+      cluster.close();
+    }
+  }
+
+  @Test
+  public void overrideDQLConfigurationWithJMSContext() throws Exception {
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties);
+        PulsarJMSContext primaryContext = factory.createContext(JMSContext.CLIENT_ACKNOWLEDGE)) {
+      Queue destination =
+          primaryContext.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+
+      Topic destinationDeadletter =
+          primaryContext.createTopic("persistent://public/default/test-dlq-" + UUID.randomUUID());
+
+      Map<String, Object> consumerConfig =
+          createConsumerConfigurationWithDQL(destinationDeadletter);
+
+      try (JMSContext overrideConsumerConfiguration =
+              primaryContext.createContext(
+                  primaryContext.getSessionMode(),
+                  ImmutableMap.of("consumerConfig", consumerConfig));
+          JMSConsumer consumerWithDLQConfiguration =
+              overrideConsumerConfiguration.createConsumer(destination); ) {
+
+        primaryContext.createProducer().send(destination, "foo");
+
+        Message message = consumerWithDLQConfiguration.receive();
+        assertEquals("foo", message.getBody(String.class));
+        assertEquals(1, message.getIntProperty("JMSXDeliveryCount"));
+        assertFalse(message.getJMSRedelivered());
+
+        // message is re-delivered again after ackTimeoutMillis
+        message = consumerWithDLQConfiguration.receive();
+        assertEquals("foo", message.getBody(String.class));
+        assertEquals(2, message.getIntProperty("JMSXDeliveryCount"));
+        assertTrue(message.getJMSRedelivered());
+
+        try (JMSConsumer consumerDeadLetter =
+            primaryContext.createSharedConsumer(destinationDeadletter, "dqlsub"); ) {
+
+          message = consumerDeadLetter.receive();
+          assertEquals("foo", message.getBody(String.class));
+          log.info("DLQ MESSAGE {}", message);
+
+          // this is another topic, and the JMSXDeliveryCount is only handled on the client side
+          // so the count is back to 1
+          assertEquals(1, message.getIntProperty("JMSXDeliveryCount"));
+          assertFalse(message.getJMSRedelivered());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void overrideDQLConfigurationWithSession() throws Exception {
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties);
+        PulsarConnection connection = factory.createConnection();
+        PulsarSession primarySession = connection.createSession(Session.CLIENT_ACKNOWLEDGE)) {
+      connection.start();
+      Queue destination =
+          primarySession.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+
+      Topic destinationDeadletter =
+          primarySession.createTopic("persistent://public/default/test-dlq-" + UUID.randomUUID());
+
+      Map<String, Object> consumerConfig =
+          createConsumerConfigurationWithDQL(destinationDeadletter);
+
+      try (PulsarSession overrideConsumerConfiguration =
+              primarySession.createSession(
+                  primarySession.getAcknowledgeMode(),
+                  ImmutableMap.of("consumerConfig", consumerConfig));
+          MessageConsumer consumerWithDLQConfiguration =
+              overrideConsumerConfiguration.createConsumer(destination); ) {
+
+        primarySession.createProducer(destination).send(primarySession.createTextMessage("foo"));
+
+        Message message = consumerWithDLQConfiguration.receive();
+        assertEquals("foo", message.getBody(String.class));
+        assertEquals(1, message.getIntProperty("JMSXDeliveryCount"));
+        assertFalse(message.getJMSRedelivered());
+
+        // message is re-delivered again after ackTimeoutMillis
+        message = consumerWithDLQConfiguration.receive();
+        assertEquals("foo", message.getBody(String.class));
+        assertEquals(2, message.getIntProperty("JMSXDeliveryCount"));
+        assertTrue(message.getJMSRedelivered());
+
+        try (MessageConsumer consumerDeadLetter =
+            primarySession.createSharedConsumer(destinationDeadletter, "dqlsub"); ) {
+
+          message = consumerDeadLetter.receive();
+          assertEquals("foo", message.getBody(String.class));
+          log.info("DLQ MESSAGE {}", message);
+
+          // this is another topic, and the JMSXDeliveryCount is only handled on the client side
+          // so the count is back to 1
+          assertEquals(1, message.getIntProperty("JMSXDeliveryCount"));
+          assertFalse(message.getJMSRedelivered());
+        }
+      }
+    }
+  }
+
+  private Map<String, Object> createConsumerConfigurationWithDQL(Topic destinationDeadletter)
+      throws JMSException {
+    Map<String, Object> consumerConfig = new HashMap<>();
+
+    consumerConfig.put("ackTimeoutMillis", 1000);
+    Map<String, Object> deadLetterPolicy = new HashMap<>();
+    consumerConfig.put("deadLetterPolicy", deadLetterPolicy);
+    deadLetterPolicy.put("maxRedeliverCount", 1);
+    deadLetterPolicy.put("deadLetterTopic", destinationDeadletter.getTopicName());
+    deadLetterPolicy.put("initialSubscriptionName", "dqlsub");
+
+    Map<String, Object> negativeAckRedeliveryBackoff = new HashMap<>();
+    consumerConfig.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
+    negativeAckRedeliveryBackoff.put("minDelayMs", 10);
+    negativeAckRedeliveryBackoff.put("maxDelayMs", 100);
+    negativeAckRedeliveryBackoff.put("multiplier", 2.0);
+
+    Map<String, Object> ackTimeoutRedeliveryBackoff = new HashMap<>();
+    consumerConfig.put("ackTimeoutRedeliveryBackoff", ackTimeoutRedeliveryBackoff);
+    ackTimeoutRedeliveryBackoff.put("minDelayMs", 10);
+    ackTimeoutRedeliveryBackoff.put("maxDelayMs", 100);
+    ackTimeoutRedeliveryBackoff.put("multiplier", 2.0);
+    return consumerConfig;
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/OverrideConsumerConfigurationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/OverrideConsumerConfigurationTest.java
@@ -69,7 +69,8 @@ public class OverrideConsumerConfigurationTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties);
-        PulsarJMSContext primaryContext = factory.createContext(JMSContext.CLIENT_ACKNOWLEDGE)) {
+        PulsarJMSContext primaryContext =
+            (PulsarJMSContext) factory.createContext(JMSContext.CLIENT_ACKNOWLEDGE)) {
       Queue destination =
           primaryContext.createQueue("persistent://public/default/test-" + UUID.randomUUID());
 


### PR DESCRIPTION
Modifications
- add JMSContext.createContext(int mode, Map<String, Object> customConfiguration)
- add Session.createSession(int mode, Map<String, Object> customConfiguration)


In order to override the consumerConfiguration the code looks like:

```

Map<String, Object> properties = ...;


Map<String, Object> overriddenProperties = new HashMap<>();
Map<String, Object> overriddenConsumerConfig = new HashMap<>();
overriddenProperties.put("consumerConfig", overriddenConsumerConfig);

try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties);
      PulsarJMSContext primaryContext = factory.createContext(JMSContext.CLIENT_ACKNOWLEDGE);
      JMSContext overrideConsumerConfiguration = primaryContext.createContext(primaryContext.getSessionMode(),
                  overriddenConsumerConfig) {
       

}
```

The same works with the JMS 1.x API (Session)


Modifications:
- move the Consumer configuration to a separate class
- add the necessary methods to the APIs
- add tests

Fixes #59 59