### PR TITLE
Support for RegEx Consumers

### DIFF
--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -113,8 +113,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -41,6 +41,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import javax.jms.*;
 import javax.jms.IllegalStateException;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -1350,6 +1352,7 @@ public class PulsarConnectionFactory
     readers.remove(reader);
   }
 
+  @SuppressFBWarnings("REC_CATCH_EXCEPTION")
   public boolean deleteSubscription(PulsarDestination destination, String name)
       throws JMSException {
     String systemNamespace = getSystemNamespace();

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -1018,20 +1018,15 @@ public class PulsarConnectionFactory
         } else {
           // if we cannot use PulsarAdmin,
           // let's try to create a consumer with zero queue
-          ConsumerBuilder<byte[]> builder =
               getPulsarClient()
                   .newConsumer()
                   .subscriptionType(getTopicSharedSubscriptionType())
                   .subscriptionName(subscriptionName)
                   .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                   .receiverQueueSize(
-                      getPrecreateQueueSubscriptionConsumerQueueSize(destination.isRegExp()));
-          if (destination.isRegExp()) {
-            builder.topicsPattern(fullQualifiedTopicName);
-          } else {
-            builder.topic(fullQualifiedTopicName);
-          }
-          builder.subscribe().close();
+                      getPrecreateQueueSubscriptionConsumerQueueSize(destination.isRegExp()))
+                  .topic(fullQualifiedTopicName)
+                  .subscribe().close();
         }
         break;
       } catch (PulsarAdminException.ConflictException exists) {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -1018,15 +1018,16 @@ public class PulsarConnectionFactory
         } else {
           // if we cannot use PulsarAdmin,
           // let's try to create a consumer with zero queue
-              getPulsarClient()
-                  .newConsumer()
-                  .subscriptionType(getTopicSharedSubscriptionType())
-                  .subscriptionName(subscriptionName)
-                  .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                  .receiverQueueSize(
-                      getPrecreateQueueSubscriptionConsumerQueueSize(destination.isRegExp()))
-                  .topic(fullQualifiedTopicName)
-                  .subscribe().close();
+          getPulsarClient()
+              .newConsumer()
+              .subscriptionType(getTopicSharedSubscriptionType())
+              .subscriptionName(subscriptionName)
+              .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+              .receiverQueueSize(
+                  getPrecreateQueueSubscriptionConsumerQueueSize(destination.isRegExp()))
+              .topic(fullQualifiedTopicName)
+              .subscribe()
+              .close();
         }
         break;
       } catch (PulsarAdminException.ConflictException exists) {
@@ -1448,6 +1449,11 @@ public class PulsarConnectionFactory
     String customSubscriptionName =
         destination.extractSubscriptionName(prependTopicNameToCustomQueueSubscriptionName);
     if (customSubscriptionName != null) {
+      if (destination.isRegExp() && prependTopicNameToCustomQueueSubscriptionName) {
+        throw new InvalidDestinationException(
+            "You cannot use WildCard destination with "
+                + "jms.prependTopicNameToCustomQueueSubscriptionName=true");
+      }
       return customSubscriptionName;
     }
     return queueSubscriptionName;

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.jms.*;
 import javax.jms.IllegalStateException;
@@ -65,6 +64,7 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TopicMetadata;
+import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 
@@ -999,39 +999,44 @@ public class PulsarConnectionFactory
     if (!isPrecreateQueueSubscription()) {
       return;
     }
+    if (destination.isRegExp()) {
+      // for regexp we cannot create the subscriptions
+      return;
+    }
     long start = System.currentTimeMillis();
 
     // please note that in the special jms-queue subscription we cannot
     // set a selector, because it is shared among all the Consumers of the Queue
     String fullQualifiedTopicName = getPulsarTopicName(destination);
     while (true) {
+      String subscriptionName = getQueueSubscriptionName(destination);
       try {
         if (isUsePulsarAdmin()) {
           getPulsarAdmin()
               .topics()
-              .createSubscription(
-                  fullQualifiedTopicName,
-                  getQueueSubscriptionName(destination),
-                  MessageId.earliest);
+              .createSubscription(fullQualifiedTopicName, subscriptionName, MessageId.earliest);
         } else {
-          // if we cannot use PulsarAdmin or we want to set a selector,
+          // if we cannot use PulsarAdmin,
           // let's try to create a consumer with zero queue
-          getPulsarClient()
-              .newConsumer()
-              .subscriptionType(getTopicSharedSubscriptionType())
-              .subscriptionName(getQueueSubscriptionName(destination))
-              .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-              .receiverQueueSize(getPrecreateQueueSubscriptionConsumerQueueSize())
-              .topic(fullQualifiedTopicName)
-              .subscribe()
-              .close();
+          ConsumerBuilder<byte[]> builder =
+              getPulsarClient()
+                  .newConsumer()
+                  .subscriptionType(getTopicSharedSubscriptionType())
+                  .subscriptionName(subscriptionName)
+                  .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                  .receiverQueueSize(
+                      getPrecreateQueueSubscriptionConsumerQueueSize(destination.isRegExp()));
+          if (destination.isRegExp()) {
+            builder.topicsPattern(fullQualifiedTopicName);
+          } else {
+            builder.topic(fullQualifiedTopicName);
+          }
+          builder.subscribe().close();
         }
         break;
       } catch (PulsarAdminException.ConflictException exists) {
         log.debug(
-            "Subscription {} already exists for {}",
-            getQueueSubscriptionName(destination),
-            fullQualifiedTopicName);
+            "Subscription {} already exists for {}", subscriptionName, fullQualifiedTopicName);
         break;
       } catch (PulsarAdminException | PulsarClientException err) {
         // special handling for server startup
@@ -1068,7 +1073,7 @@ public class PulsarConnectionFactory
       boolean noLocal,
       String jmsConnectionID,
       ConsumerConfiguration overrideConsumerConfiguration,
-      AtomicReference<String> selectorOnSubscriptionReceiver)
+      Map<String, String> selectorOnSubscriptionReceiver)
       throws JMSException {
     String fullQualifiedTopicName = getPulsarTopicName(destination);
     // for queues we have a single shared subscription
@@ -1121,12 +1126,6 @@ public class PulsarConnectionFactory
     }
 
     try {
-      downloadServerSideFilter(
-          fullQualifiedTopicName,
-          subscriptionName,
-          subscriptionMode,
-          selectorOnSubscriptionReceiver);
-
       ConsumerConfiguration consumerConfiguration =
           getConsumerConfiguration(overrideConsumerConfiguration);
       Schema<?> schema = consumerConfiguration.getConsumerSchema();
@@ -1145,8 +1144,12 @@ public class PulsarConnectionFactory
               .subscriptionMode(subscriptionMode)
               .subscriptionProperties(subscriptionProperties)
               .subscriptionType(subscriptionType)
-              .subscriptionName(subscriptionName)
-              .topic(fullQualifiedTopicName);
+              .subscriptionName(subscriptionName);
+      if (destination.isRegExp()) {
+        builder.topicsPattern(fullQualifiedTopicName);
+      } else {
+        builder.topic(fullQualifiedTopicName);
+      }
       if (consumerConfiguration.getDeadLetterPolicy() != null) {
         builder.deadLetterPolicy(consumerConfiguration.getDeadLetterPolicy());
       }
@@ -1160,6 +1163,26 @@ public class PulsarConnectionFactory
       Consumer<?> newConsumer = builder.subscribe();
       consumers.add(newConsumer);
 
+      if (newConsumer instanceof MultiTopicsConsumerImpl) {
+        MultiTopicsConsumerImpl multiTopicsConsumer = (MultiTopicsConsumerImpl) newConsumer;
+        if (log.isDebugEnabled()) {
+          log.debug("Partition names: {}", multiTopicsConsumer.getPartitions());
+        }
+        for (Object singleTopicName : multiTopicsConsumer.getPartitions()) {
+          downloadServerSideFilter(
+              singleTopicName.toString(),
+              subscriptionName,
+              subscriptionMode,
+              selectorOnSubscriptionReceiver);
+        }
+      } else {
+        downloadServerSideFilter(
+            fullQualifiedTopicName,
+            subscriptionName,
+            subscriptionMode,
+            selectorOnSubscriptionReceiver);
+      }
+
       return newConsumer;
     } catch (PulsarClientException | PulsarAdminException err) {
       throw Utils.handleException(err);
@@ -1170,7 +1193,7 @@ public class PulsarConnectionFactory
       String fullQualifiedTopicName,
       String subscriptionName,
       SubscriptionMode subscriptionMode,
-      AtomicReference<String> selectorOnSubscriptionReceiver)
+      Map<String, String> selectorOnSubscriptionReceiver)
       throws PulsarAdminException, JMSException {
     if (!isUseServerSideFiltering() || subscriptionMode != SubscriptionMode.Durable) {
       return;
@@ -1194,7 +1217,7 @@ public class PulsarConnectionFactory
                   selectorOnSubscription,
                   subscriptionName,
                   fullQualifiedTopicName);
-              selectorOnSubscriptionReceiver.set(selectorOnSubscription);
+              selectorOnSubscriptionReceiver.put(fullQualifiedTopicName, selectorOnSubscription);
             }
           }
         }
@@ -1228,20 +1251,15 @@ public class PulsarConnectionFactory
   public List<Reader<?>> createReadersForBrowser(
       PulsarQueue destination,
       ConsumerConfiguration overrideConsumerConfiguration,
-      AtomicReference<String> selectorOnSubscriptionReceiver)
+      Map<String, String> selectorOnSubscriptionReceiver)
       throws JMSException {
+
+    if (destination.isRegExp()) {
+      throw new InvalidDestinationException("QueueBrowser is not supported for WildCard queues");
+    }
 
     String fullQualifiedTopicName = getPulsarTopicName(destination);
     String queueSubscriptionName = getQueueSubscriptionName(destination);
-    try {
-      downloadServerSideFilter(
-          fullQualifiedTopicName,
-          queueSubscriptionName,
-          SubscriptionMode.Durable,
-          selectorOnSubscriptionReceiver);
-    } catch (PulsarAdminException err) {
-      throw Utils.handleException(err);
-    }
 
     try {
       PartitionedTopicMetadata partitionedTopicMetadata =
@@ -1251,6 +1269,11 @@ public class PulsarConnectionFactory
         Reader<?> readerForBrowserForNonPartitionedTopic =
             createReaderForBrowserForNonPartitionedTopic(
                 queueSubscriptionName, fullQualifiedTopicName, overrideConsumerConfiguration);
+        downloadServerSideFilter(
+            fullQualifiedTopicName,
+            queueSubscriptionName,
+            SubscriptionMode.Durable,
+            selectorOnSubscriptionReceiver);
         readers.add(readerForBrowserForNonPartitionedTopic);
       } else {
         for (int i = 0; i < partitionedTopicMetadata.partitions; i++) {
@@ -1258,6 +1281,11 @@ public class PulsarConnectionFactory
           Reader<?> readerForBrowserForNonPartitionedTopic =
               createReaderForBrowserForNonPartitionedTopic(
                   queueSubscriptionName, partitionName, overrideConsumerConfiguration);
+          downloadServerSideFilter(
+              partitionName,
+              queueSubscriptionName,
+              SubscriptionMode.Durable,
+              selectorOnSubscriptionReceiver);
           readers.add(readerForBrowserForNonPartitionedTopic);
         }
       }
@@ -1333,6 +1361,10 @@ public class PulsarConnectionFactory
     try {
 
       if (destination != null) {
+        if (destination.isRegExp()) {
+          throw new InvalidDestinationException(
+              "Regex destinations are not supported for unsubscribe");
+        }
         String fullQualifiedTopicName = getPulsarTopicName(destination);
         log.info("deleteSubscription topic {} name {}", fullQualifiedTopicName, name);
         try {
@@ -1459,7 +1491,10 @@ public class PulsarConnectionFactory
     return closed;
   }
 
-  private synchronized int getPrecreateQueueSubscriptionConsumerQueueSize() {
+  private synchronized int getPrecreateQueueSubscriptionConsumerQueueSize(boolean regExp) {
+    if (regExp) {
+      return Math.max(precreateQueueSubscriptionConsumerQueueSize, 1);
+    }
     return precreateQueueSubscriptionConsumerQueueSize;
   }
 

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarDestination.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarDestination.java
@@ -45,7 +45,14 @@ public abstract class PulsarDestination implements Destination {
   }
 
   public String getInternalTopicName() {
+    if (isRegExp()) {
+      return topicName.substring("regex:".length());
+    }
     return topicName;
+  }
+
+  public boolean isRegExp() {
+    return topicName.startsWith("regex:");
   }
 
   public abstract boolean isQueue();

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueue.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueue.java
@@ -100,7 +100,7 @@ public final class PulsarQueue extends PulsarDestination implements Queue {
     if (pos < 0) {
       return null;
     }
-    String subscriptionName  = shortTopicName.substring(pos + 1);
+    String subscriptionName = shortTopicName.substring(pos + 1);
     if (subscriptionName.isEmpty()) {
       throw new InvalidDestinationException("Subscription name cannot be empty");
     }
@@ -113,6 +113,7 @@ public final class PulsarQueue extends PulsarDestination implements Queue {
 
   /**
    * return the topic name, without the embedded subscription
+   *
    * @return
    */
   public String getInternalTopicName() {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueue.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueue.java
@@ -58,51 +58,92 @@ public final class PulsarQueue extends PulsarDestination implements Queue {
    */
   public String extractSubscriptionName(boolean prependTopicNameToCustomQueueSubscriptionName)
       throws InvalidDestinationException {
+
     // only valid cases
-    // queue:subscription
+    // regexp:persistent://public/default/queue:subscription
+    // regexp:non-persistent://public/default/queue:subscription
+    // regexp:public/default/queue:subscription
+    // regexp:queue:subscription
     // persistent://public/default/queue:subscription
-    int pos = topicName.lastIndexOf(":");
+    // non-persistent://public/default/queue:subscription
+    // public/default/queue:subscription
+    // queue:subscription
+
+    // regexp:persistent://public/default/queue
+    // regexp:non-persistent://public/default/queue
+    // regexp:public/default/queue
+    // regexp:queue
+    // persistent://public/default/queue
+    // non-persistent://public/default/queue
+    // public/default/queue
+    // queue
+
+    String shortTopicName = topicName;
+
+    if (shortTopicName.startsWith("regex:")) {
+      shortTopicName = shortTopicName.substring("regex:".length());
+    }
+    int endSchema = shortTopicName.indexOf("://");
+    if (endSchema > 0) {
+      shortTopicName = shortTopicName.substring(endSchema + 3);
+    }
+    int lastSlash = shortTopicName.lastIndexOf('/');
+    if (lastSlash > 0) {
+      shortTopicName = shortTopicName.substring(lastSlash + 1);
+    }
+
+    // here we have only
+    // queue
+    // queue:subscription
+
+    int pos = shortTopicName.lastIndexOf(":");
     if (pos < 0) {
       return null;
     }
-    String subscriptionName = topicName.substring(pos + 1);
+    String subscriptionName  = shortTopicName.substring(pos + 1);
     if (subscriptionName.isEmpty()) {
-      throw new InvalidDestinationException(
-          "Subscription name cannot be empty, original topic name is " + topicName);
+      throw new InvalidDestinationException("Subscription name cannot be empty");
     }
-
-    // return only the "subscription" part
-    if (!prependTopicNameToCustomQueueSubscriptionName) {
+    if (prependTopicNameToCustomQueueSubscriptionName) {
+      return shortTopicName;
+    } else {
       return subscriptionName;
     }
-
-    // prepend the topic name:
-    // we include the short topic name in the subscription name
-    // because in Pulsar subscription level permissions are namespace scoped
-    // and not topic-scoped, so it is better that the subscription name
-    // is unique in the scope of a namespace
-    int slash = topicName.lastIndexOf("/");
-
-    if (slash < 0 || slash < pos) {
-      if (slash < 0) {
-        // queue:subscription
-        return topicName;
-      } else {
-        // persistent://public/default/queue:subscription
-        return topicName.substring(slash + 1);
-      }
-    }
-    return null;
   }
 
+  /**
+   * return the topic name, without the embedded subscription
+   * @return
+   */
   public String getInternalTopicName() {
+    String topicName = this.topicName;
+    // regexp:persistent://public/default/queue:subscription
+    // regexp:non-persistent://public/default/queue:subscription
+    // regexp:public/default/queue:subscription
+    // regexp:queue:subscription
+    // persistent://public/default/queue:subscription
+    // non-persistent://public/default/queue:subscription
+    // public/default/queue:subscription
+    // queue:subscription
+
+    // regexp:persistent://public/default/queue
+    // regexp:non-persistent://public/default/queue
+    // regexp:public/default/queue
+    // regexp:queue
+    // persistent://public/default/queue
+    // non-persistent://public/default/queue
+    // public/default/queue
+    // queue
+
+    if (topicName.startsWith("regex:")) {
+      topicName = topicName.substring("regex:".length());
+    }
+    // no colon, early exit
     int pos = topicName.lastIndexOf(":");
     if (pos < 0) {
       return topicName;
     }
-    // only valid cases
-    // queue:subscription
-    // persistent://public/default/queue:subscription
+
     int slash = topicName.lastIndexOf("/");
     if (slash < 0 || slash < pos) {
       return topicName.substring(0, pos);

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/MultiTopicConsumerTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/MultiTopicConsumerTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.jms.Connection;
+import javax.jms.InvalidDestinationException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.QueueBrowser;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Slf4j
+public class MultiTopicConsumerTest {
+
+  @TempDir public static Path tempDir;
+  private static PulsarCluster cluster;
+
+  @BeforeAll
+  public static void before() throws Exception {
+    cluster =
+        new PulsarCluster(
+            tempDir,
+            serviceConfiguration -> {
+              serviceConfiguration.setTransactionCoordinatorEnabled(false);
+              serviceConfiguration.setAllowAutoTopicCreation(false);
+            });
+    cluster.start();
+  }
+
+  @AfterAll
+  public static void after() throws Exception {
+    if (cluster != null) {
+      cluster.close();
+    }
+  }
+
+  @Test
+  public void testMultiTopicNonPartitioned() throws Exception {
+    testMultiTopic(0);
+  }
+
+  @Test
+  public void testMultiTopicPartitioned() throws Exception {
+    testMultiTopic(4);
+  }
+
+  private void testMultiTopic(int numPartitions) throws Exception {
+    int numMessagesPerDestination = 10;
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.usePulsarAdmin", "true");
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (Connection connection = factory.createConnection()) {
+        connection.start();
+        try (Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            MessageProducer producer = session.createProducer(null)) {
+          String prefix = UUID.randomUUID().toString();
+
+          List<Topic> destinationsToWrite = new ArrayList<>();
+          for (int i = 0; i < 4; i++) {
+            String topicName = "test-" + prefix + "-" + i;
+            if (numPartitions > 0) {
+              factory.getPulsarAdmin().topics().createPartitionedTopic(topicName, numPartitions);
+            } else {
+              factory.getPulsarAdmin().topics().createNonPartitionedTopic(topicName);
+            }
+            destinationsToWrite.add(session.createTopic(topicName));
+          }
+
+          Set<String> payloads = new HashSet<>();
+          int count = 0;
+          for (int i = 0; i < numMessagesPerDestination; i++) {
+            for (Topic destination : destinationsToWrite) {
+              String payload = "foo - " + count * i;
+              log.info("write {} to {}", payload, destination);
+              producer.send(destination, session.createTextMessage(payload));
+              count++;
+            }
+          }
+
+          Queue destination =
+              session.createQueue("regex:persistent://public/default/test-" + prefix + "-.*");
+          PulsarDestination asPulsarDestination = (PulsarDestination) destination;
+          assertTrue(asPulsarDestination.isRegExp());
+
+          try (MessageConsumer consumer = session.createConsumer(destination); ) {
+            for (int i = 0; i < count; i++) {
+              String payload = consumer.receive().getBody(String.class);
+              log.info("Received {}, remaining {}", payload, payloads.size());
+              assertFalse(payloads.remove(payload));
+            }
+          }
+          assertTrue(payloads.isEmpty());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void sendUsingExistingPulsarSubscriptionWithServerSideFilterForNonPartitionedQueue()
+      throws Exception {
+    sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(0, false);
+  }
+
+  @Test
+  public void sendUsingExistingPulsarSubscriptionWithServerSideFilterForPartitionedQueue()
+      throws Exception {
+    sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(4, false);
+  }
+
+  @Test
+  public void sendUsingExistingPulsarSubscriptionWithServerSideFilterForNonPartitionedQueueWithCustomSubscription()
+          throws Exception {
+    sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(0, true);
+  }
+
+  @Test
+  public void sendUsingExistingPulsarSubscriptionWithServerSideFilterForPartitionedQueueWithCustomSubscription()
+          throws Exception {
+    sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(4, true);
+  }
+
+  private void sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(int numPartitions, boolean embedSubscriptionName)
+      throws Exception {
+
+    String prefix = "test-" + UUID.randomUUID();
+    String subscriptionName = "the-sub";
+    String selector = "keepme = TRUE";
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.usePulsarAdmin", "true");
+    properties.put("jms.useServerSideFiltering", "true");
+
+    properties.put("jms.prependTopicNameToCustomQueueSubscriptionName", "false");
+    if (!embedSubscriptionName) {
+      properties.put("jms.queueSubscriptionName", subscriptionName);
+    }
+
+    Map<String, String> subscriptionProperties = new HashMap<>();
+    subscriptionProperties.put("jms.selector", selector);
+    subscriptionProperties.put("jms.filtering", "true");
+
+    List<Queue> destinationsToWrite = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      String topicName = prefix + "-" + i;
+      if (numPartitions > 0) {
+        cluster
+            .getService()
+            .getAdminClient()
+            .topics()
+            .createPartitionedTopic(topicName, numPartitions);
+      } else {
+        cluster.getService().getAdminClient().topics().createNonPartitionedTopic(topicName);
+      }
+
+      // create a Subscription with a selector
+      cluster
+          .getService()
+          .getAdminClient()
+          .topics()
+          .createSubscription(
+              topicName, subscriptionName, MessageId.earliest, false, subscriptionProperties);
+      destinationsToWrite.add(new PulsarQueue(topicName));
+    }
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (PulsarConnection connection = factory.createConnection()) {
+        connection.start();
+        try (PulsarSession session = connection.createSession(); ) {
+
+          String pattern = "regex:persistent://public/default/" + prefix + ".*";
+          if (embedSubscriptionName) {
+            pattern = pattern + ":" + subscriptionName;
+          }
+          Queue wildcardDestination =
+              session.createQueue(pattern);
+
+          // do not set the selector, it will be loaded from the Subscription Properties
+          try (PulsarMessageConsumer consumer1 = session.createConsumer(wildcardDestination); ) {
+            assertEquals(
+                SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
+
+            // this is downloaded from the server
+            // getMessageSelector returns any of the selectors actually
+            assertEquals(selector, consumer1.getMessageSelector());
+
+            try (MessageProducer producer = session.createProducer(null); ) {
+              for (int i = 0; i < 10; i++) {
+                TextMessage textMessage = session.createTextMessage("foo-" + i);
+                if (i % 2 == 0) {
+                  textMessage.setBooleanProperty("keepme", true);
+                }
+                for (Queue queue : destinationsToWrite) {
+                  producer.send(queue, textMessage);
+                  log.info("Sent {} to {}", textMessage.getText(), queue);
+                }
+              }
+            }
+
+            assertThrows(InvalidDestinationException.class, () -> session.createBrowser(wildcardDestination));
+
+            // with a partitioned/multi topic we don't have control over ordering
+            List<String> received = new ArrayList<>();
+            for (int i = 0; i < 10 * destinationsToWrite.size(); i++) {
+              if (i % 2 == 0) {
+                TextMessage textMessage = (TextMessage) consumer1.receive();
+                log.info(
+                    "Received {} from {}", textMessage.getText(), textMessage.getJMSDestination());
+                received.add(textMessage.getText());
+              }
+            }
+            for (int i = 0; i < 10; i++) {
+              for (int j = 0; j < destinationsToWrite.size(); j++) {
+                if (i % 2 == 0) {
+                  String expected = "foo-" + i;
+                  log.info("Removing {} from {}", expected, received);
+                  assertTrue(received.remove("foo-" + i));
+                }
+              }
+            }
+            assertTrue(received.isEmpty());
+
+            assertEquals(5 * destinationsToWrite.size(), consumer1.getReceivedMessages());
+            assertEquals(0, consumer1.getSkippedMessages());
+
+            // no more messages
+            assertNull(consumer1.receiveNoWait());
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void sendUsingExistingPulsarSubscriptionWithClientSideFilterForNonPartitionedQueue()
+      throws Exception {
+    sendUsingExistingPulsarSubscriptionWithClientSideFilterForPartitionedQueue(0);
+  }
+
+  @Test
+  public void sendUsingExistingPulsarSubscriptionWithClientSideFilterForPartitionedQueue()
+      throws Exception {
+    sendUsingExistingPulsarSubscriptionWithClientSideFilterForPartitionedQueue(4);
+  }
+
+  private void sendUsingExistingPulsarSubscriptionWithClientSideFilterForPartitionedQueue(
+      int numPartitions) throws Exception {
+
+    String prefix = "test-" + UUID.randomUUID();
+    String subscriptionName = "the-sub";
+    String selector = "keepme = TRUE";
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.usePulsarAdmin", "true");
+    properties.put("jms.useServerSideFiltering", "false");
+    properties.put("jms.enableClientSideEmulation", "true");
+    properties.put("jms.acknowledgeRejectedMessages", "true");
+    properties.put("jms.queueSubscriptionName", subscriptionName);
+
+    List<Queue> destinationsToWrite = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      String topicName = prefix + "-" + i;
+      if (numPartitions > 0) {
+        cluster
+            .getService()
+            .getAdminClient()
+            .topics()
+            .createPartitionedTopic(topicName, numPartitions);
+      } else {
+        cluster.getService().getAdminClient().topics().createNonPartitionedTopic(topicName);
+      }
+
+      // create a Subscription with a selector
+      cluster
+          .getService()
+          .getAdminClient()
+          .topics()
+          .createSubscription(topicName, subscriptionName, MessageId.earliest, false);
+      destinationsToWrite.add(new PulsarQueue(topicName));
+    }
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (PulsarConnection connection = factory.createConnection()) {
+        connection.start();
+        try (PulsarSession session = connection.createSession(); ) {
+
+          Queue wildcardDestination =
+              session.createQueue("regex:persistent://public/default/" + prefix + ".*");
+
+          // do not set the selector, it will be loaded from the Subscription Properties
+          try (PulsarMessageConsumer consumer1 =
+              session.createConsumer(wildcardDestination, selector); ) {
+            assertEquals(
+                SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
+
+            assertEquals(selector, consumer1.getMessageSelector());
+
+            int totalSent = 0;
+            try (MessageProducer producer = session.createProducer(null); ) {
+              for (int i = 0; i < 10; i++) {
+                TextMessage textMessage = session.createTextMessage("foo-" + i);
+                if (i % 2 == 0) {
+                  textMessage.setBooleanProperty("keepme", true);
+                }
+                for (Queue queue : destinationsToWrite) {
+                  producer.send(queue, textMessage);
+                  totalSent++;
+                }
+              }
+            }
+
+            int totalReceived = 0;
+            // with a partitioned topic we don't have control over ordering
+            List<String> received = new ArrayList<>();
+            for (int i = 0; i < 10 * destinationsToWrite.size(); i++) {
+              if (i % 2 == 0) {
+                TextMessage textMessage = (TextMessage) consumer1.receive();
+                received.add(textMessage.getText());
+                totalReceived++;
+              }
+            }
+            for (int i = 0; i < 10; i++) {
+              for (int j = 0; j < destinationsToWrite.size(); j++) {
+                if (i % 2 == 0) {
+                  String expected = "foo-" + i;
+                  assertTrue(received.remove("foo-" + i));
+                }
+              }
+            }
+            assertTrue(received.isEmpty());
+
+            // drain the last messages, the will be skipped on the client side
+            assertNull(consumer1.receive(1000));
+            assertNull(consumer1.receive(1000));
+            assertNull(consumer1.receive(1000));
+            assertNull(consumer1.receive(1000));
+
+            assertEquals(totalSent, consumer1.getReceivedMessages());
+            assertEquals(totalSent - totalReceived, consumer1.getSkippedMessages());
+
+            // no more messages
+            assertNull(consumer1.receiveNoWait());
+          }
+        }
+      }
+    }
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/MultiTopicConsumerTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/MultiTopicConsumerTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,7 +35,6 @@ import javax.jms.InvalidDestinationException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
-import javax.jms.QueueBrowser;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
@@ -149,19 +147,21 @@ public class MultiTopicConsumerTest {
   }
 
   @Test
-  public void sendUsingExistingPulsarSubscriptionWithServerSideFilterForNonPartitionedQueueWithCustomSubscription()
+  public void
+      sendUsingExistingPulsarSubscriptionWithServerSideFilterForNonPartitionedQueueWithCustomSubscription()
           throws Exception {
     sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(0, true);
   }
 
   @Test
-  public void sendUsingExistingPulsarSubscriptionWithServerSideFilterForPartitionedQueueWithCustomSubscription()
+  public void
+      sendUsingExistingPulsarSubscriptionWithServerSideFilterForPartitionedQueueWithCustomSubscription()
           throws Exception {
     sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(4, true);
   }
 
-  private void sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(int numPartitions, boolean embedSubscriptionName)
-      throws Exception {
+  private void sendUsingExistingPulsarSubscriptionWithServerSideFilterForQueue(
+      int numPartitions, boolean embedSubscriptionName) throws Exception {
 
     String prefix = "test-" + UUID.randomUUID();
     String subscriptionName = "the-sub";
@@ -213,8 +213,7 @@ public class MultiTopicConsumerTest {
           if (embedSubscriptionName) {
             pattern = pattern + ":" + subscriptionName;
           }
-          Queue wildcardDestination =
-              session.createQueue(pattern);
+          Queue wildcardDestination = session.createQueue(pattern);
 
           // do not set the selector, it will be loaded from the Subscription Properties
           try (PulsarMessageConsumer consumer1 = session.createConsumer(wildcardDestination); ) {
@@ -238,7 +237,9 @@ public class MultiTopicConsumerTest {
               }
             }
 
-            assertThrows(InvalidDestinationException.class, () -> session.createBrowser(wildcardDestination));
+            assertThrows(
+                InvalidDestinationException.class,
+                () -> session.createBrowser(wildcardDestination));
 
             // with a partitioned/multi topic we don't have control over ordering
             List<String> received = new ArrayList<>();

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarDestinationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarDestinationTest.java
@@ -48,6 +48,15 @@ public class PulsarDestinationTest {
     topic = new PulsarQueue("persistent://public/default/test:sub");
     assertEquals("test:sub", topic.extractSubscriptionName(true));
 
+    topic = new PulsarQueue("persistent://public/default/test");
+    assertEquals(null, topic.extractSubscriptionName(true));
+
+    topic = new PulsarQueue("regex:persistent://public/default/test");
+    assertEquals(null, topic.extractSubscriptionName(true));
+
+    topic = new PulsarQueue("regexp:persistent://public/default/test:sub");
+    assertEquals("test:sub", topic.extractSubscriptionName(true));
+
     assertThrows(
         InvalidDestinationException.class,
         () -> {
@@ -69,6 +78,15 @@ public class PulsarDestinationTest {
 
     topic = new PulsarQueue("persistent://public/default/test:sub");
     assertEquals("sub", topic.extractSubscriptionName(false));
+
+    topic = new PulsarQueue("regex:persistent://public/default/test:sub");
+    assertEquals("sub", topic.extractSubscriptionName(false));
+
+    topic = new PulsarQueue("persistent://public/default/test");
+    assertEquals(null, topic.extractSubscriptionName(false));
+
+    topic = new PulsarQueue("regex:persistent://public/default/test");
+    assertEquals(null, topic.extractSubscriptionName(false));
 
     assertThrows(
         InvalidDestinationException.class,

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -829,9 +829,10 @@ public abstract class SelectorsTestsBase {
               }
               for (int i = 0; i < 10; i++) {
                 if (i % 2 == 0) {
-                  assertTrue(received.contains("foo-" + i));
+                  assertTrue(received.remove("foo-" + i));
                 }
               }
+              assertTrue(received.isEmpty());
             }
 
             assertEquals(5, consumer1.getReceivedMessages());


### PR DESCRIPTION
This is only a POC to demonstrate a possible API to support multi topic consumers
https://pulsar.apache.org/docs/concepts-messaging/#multi-topic-subscriptions

the idea of this patch is to support Queues (and Topics) with regex

```
Queue destination =
                  session.createQueue("regex:persistent://public/default/test-.*");
Queue destination =
                  session.createQueue("regex:persistent://public/default/test-.*:SUBSCRIPTIONAME");
```

This in turn maps to "topicsPattern" in ConsumerBuilder.

This is only a POC because the implementation needs more work, especially for server-side selectors.
For server-side selectors we are downloading the "per-subscription" selector using pulsar-admin and PulsarAdmin APIs don't support regexps (this is good and we won't change it).

So in every code path in which we use PulsarAdmin we have to download the list of topics in the namespace as Pulsar does here https://github.com/apache/pulsar/blob/9bdf4948dd733e699d52e01549ac935929058915/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java#L578
and then apply the pattern.

There will also be to understand (and make it configurable) how often poll for "new topics" that match the pattern.

We should also support not only "regexp" but passing a fixed list of Topics