### PR TITLE
[Transactions] - Allow session.commit() and session.rollback() in MessageListener

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -365,126 +365,117 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
       java.util.function.Consumer<PulsarMessage> listenerCode,
       boolean noLocalFilter)
       throws JMSException, org.apache.pulsar.client.api.PulsarClientException {
-    session.blockTransactionOperations();
+    receivedMessages.incrementAndGet();
 
-    try {
-
-      receivedMessages.incrementAndGet();
-
-      PulsarMessage result = PulsarMessage.decode(this, message);
-      Consumer<?> consumer = getConsumer();
-      if (expectedType != null && !result.isBodyAssignableTo(expectedType)) {
-        if (log.isDebugEnabled()) {
-          log.debug(
-              "negativeAcknowledge for message {} that cannot be converted to {}",
-              message,
-              expectedType);
-        }
-        consumer.negativeAcknowledge(message);
-        throw new MessageFormatException(
-            "The message ("
-                + result.messageType()
-                + ","
-                + result
-                + ",) cannot be converted to a "
-                + expectedType);
+    PulsarMessage result = PulsarMessage.decode(this, message);
+    Consumer<?> consumer = getConsumer();
+    if (expectedType != null && !result.isBodyAssignableTo(expectedType)) {
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "negativeAcknowledge for message {} that cannot be converted to {}",
+            message,
+            expectedType);
       }
-      SelectorSupport selectorSupportOnSubscription = getSelectorSupportOnSubscription();
-      if (selectorSupportOnSubscription != null
-          && requiresClientSideFiltering(message)
-          && !selectorSupportOnSubscription.matches(result)) {
-        if (log.isDebugEnabled()) {
-          log.debug(
-              "msg {} does not match subscription selector {}",
-              result,
-              selectorSupportOnSubscription.getSelector());
-        }
-        // this message should have been filtered out on the server
-        // because the selector is on the subscription
-        // this case may happen with batch messages
-        skippedMessages.incrementAndGet();
-        consumer.acknowledgeAsync(message.getMessageId());
-        return null;
-      }
-      SelectorSupport selectorSupport = getSelectorSupport();
-      if (selectorSupport != null
-          && requiresClientSideFiltering(message)
-          && !selectorSupport.matches(result)) {
-        if (log.isDebugEnabled()) {
-          log.debug("msg {} does not match selector {}", result, selectorSupport.getSelector());
-        }
-        skipMessage(message);
-        return null;
-      }
-      if (noLocalFilter) {
-        String senderConnectionID = result.getStringProperty("JMSConnectionID");
-        if (senderConnectionID != null
-            && senderConnectionID.equals(session.getConnection().getConnectionId())) {
-          if (log.isDebugEnabled()) {
-            log.debug("msg {} was generated from this connection {}", result, senderConnectionID);
-          }
-          skipMessage(message);
-          return null;
-        }
-      }
-      // in case of useServerSideFiltering this filter is also applied on the broker, is the Plugin
-      // is
-      // present
-      if (result.getJMSExpiration() > 0
-          && System.currentTimeMillis() >= result.getJMSExpiration()) {
-        if (log.isDebugEnabled()) {
-          log.debug(
-              "msg {} expired at {}", result, Instant.ofEpochMilli(result.getJMSExpiration()));
-        }
-        skipMessage(message);
-        return null;
-      }
-
-      // this must happen before the execution of the listener
-      // in order to support Session.recover
-      session.registerUnacknowledgedMessage(result);
-
-      if (listenerCode != null) {
-        try {
-          listenerCode.accept(result);
-        } catch (Throwable t) {
-          log.error("Listener thrown error, calling negativeAcknowledge", t);
-          consumer.negativeAcknowledge(message);
-          throw Utils.handleException(t);
-        }
-        if (result.isNegativeAcked()) {
-          // this may happen if the listener calls "Session.recover"
-          return null;
-        }
-      }
-
-      if (session.getTransacted()) {
-        // open transaction now, the message will be acknowledged on commit()
-        session.getTransaction();
-      } else if (session.getAcknowledgeMode() == Session.AUTO_ACKNOWLEDGE) {
-        consumer.acknowledge(message);
-      } else if (session.getAcknowledgeMode() == Session.DUPS_OK_ACKNOWLEDGE) {
-        consumer
-            .acknowledgeAsync(message)
-            .whenComplete(
-                (m, ex) -> {
-                  if (ex != null) {
-                    log.error("Cannot acknowledge message {} {}", message, ex);
-                  }
-                });
-      }
-      if (session.getAcknowledgeMode() != Session.CLIENT_ACKNOWLEDGE
-          && session.getAcknowledgeMode() != PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE
-          && session.getAcknowledgeMode() != Session.SESSION_TRANSACTED) {
-        session.unregisterUnacknowledgedMessage(result);
-      }
-      if (requestClose) {
-        closeInternal();
-      }
-      return result;
-    } finally {
-      session.unblockTransactionOperations();
+      consumer.negativeAcknowledge(message);
+      throw new MessageFormatException(
+          "The message ("
+              + result.messageType()
+              + ","
+              + result
+              + ",) cannot be converted to a "
+              + expectedType);
     }
+    SelectorSupport selectorSupportOnSubscription = getSelectorSupportOnSubscription();
+    if (selectorSupportOnSubscription != null
+        && requiresClientSideFiltering(message)
+        && !selectorSupportOnSubscription.matches(result)) {
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "msg {} does not match subscription selector {}",
+            result,
+            selectorSupportOnSubscription.getSelector());
+      }
+      // this message should have been filtered out on the server
+      // because the selector is on the subscription
+      // this case may happen with batch messages
+      skippedMessages.incrementAndGet();
+      consumer.acknowledgeAsync(message.getMessageId());
+      return null;
+    }
+    SelectorSupport selectorSupport = getSelectorSupport();
+    if (selectorSupport != null
+        && requiresClientSideFiltering(message)
+        && !selectorSupport.matches(result)) {
+      if (log.isDebugEnabled()) {
+        log.debug("msg {} does not match selector {}", result, selectorSupport.getSelector());
+      }
+      skipMessage(message);
+      return null;
+    }
+    if (noLocalFilter) {
+      String senderConnectionID = result.getStringProperty("JMSConnectionID");
+      if (senderConnectionID != null
+          && senderConnectionID.equals(session.getConnection().getConnectionId())) {
+        if (log.isDebugEnabled()) {
+          log.debug("msg {} was generated from this connection {}", result, senderConnectionID);
+        }
+        skipMessage(message);
+        return null;
+      }
+    }
+    // in case of useServerSideFiltering this filter is also applied on the broker, is the Plugin
+    // is
+    // present
+    if (result.getJMSExpiration() > 0 && System.currentTimeMillis() >= result.getJMSExpiration()) {
+      if (log.isDebugEnabled()) {
+        log.debug("msg {} expired at {}", result, Instant.ofEpochMilli(result.getJMSExpiration()));
+      }
+      skipMessage(message);
+      return null;
+    }
+
+    // this must happen before the execution of the listener
+    // in order to support Session.recover
+    session.registerUnacknowledgedMessage(result);
+
+    if (listenerCode != null) {
+      try {
+        listenerCode.accept(result);
+      } catch (Throwable t) {
+        log.error("Listener thrown error, calling negativeAcknowledge", t);
+        consumer.negativeAcknowledge(message);
+        throw Utils.handleException(t);
+      }
+      if (result.isNegativeAcked()) {
+        // this may happen if the listener calls "Session.recover"
+        return null;
+      }
+    }
+
+    if (session.getTransacted()) {
+      // open transaction now, the message will be acknowledged on commit()
+      session.getTransaction();
+    } else if (session.getAcknowledgeMode() == Session.AUTO_ACKNOWLEDGE) {
+      consumer.acknowledge(message);
+    } else if (session.getAcknowledgeMode() == Session.DUPS_OK_ACKNOWLEDGE) {
+      consumer
+          .acknowledgeAsync(message)
+          .whenComplete(
+              (m, ex) -> {
+                if (ex != null) {
+                  log.error("Cannot acknowledge message {} {}", message, ex);
+                }
+              });
+    }
+    if (session.getAcknowledgeMode() != Session.CLIENT_ACKNOWLEDGE
+        && session.getAcknowledgeMode() != PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE
+        && session.getAcknowledgeMode() != Session.SESSION_TRANSACTED) {
+      session.unregisterUnacknowledgedMessage(result);
+    }
+    if (requestClose) {
+      closeInternal();
+    }
+    return result;
   }
 
   private boolean requiresClientSideFiltering(org.apache.pulsar.client.api.Message<?> message) {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
@@ -171,7 +171,7 @@ public final class Utils {
         && current.session == session
         && ((producer != null && current.producer == producer)
             || // specific producer
-            (producer == null || current.producer != null))) // any producer
+            (producer == null && current.producer != null))) // any producer
     {
       throw new IllegalStateException("Cannot call this method inside a CompletionListener");
     }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -636,6 +636,8 @@ public class TransactionsTest {
     properties.put("enableTransaction", "true");
     Map<String, Object> producerConfig = new HashMap<>();
     producerConfig.put("batchingEnabled", true);
+    producerConfig.put("batchingMaxPublishDelayMicros", TimeUnit.SECONDS.toMicros(5));
+    producerConfig.put("batchingMaxMessages", 2);
     properties.put("producerConfig", producerConfig);
 
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.jms.CompletionListener;
 import javax.jms.Connection;
 import javax.jms.Destination;
@@ -785,6 +787,88 @@ public class TransactionsTest {
 
               received.clear();
               consumerSession.commit();
+
+              // verify no message is received anymore
+              Awaitility.await().during(4, TimeUnit.SECONDS).until(() -> received.isEmpty());
+
+              // verify no other consumer is able to receive the message
+              try (Session otherConsumer = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+                  MessageConsumer consumer1 = otherConsumer.createConsumer(destination)) {
+                assertNull(consumer1.receive(1000));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void commitInsideMessageListenerTest() throws Exception {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("enableTransaction", "true");
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (Connection connection = factory.createConnection()) {
+        connection.start();
+
+        try (Session consumerSession = connection.createSession(Session.SESSION_TRANSACTED); ) {
+          Destination destination =
+              consumerSession.createTopic("persistent://public/default/test-" + UUID.randomUUID());
+          List<Message> received = new CopyOnWriteArrayList<>();
+          AtomicReference<Throwable> error = new AtomicReference<>();
+          AtomicBoolean commitDone = new AtomicBoolean();
+          AtomicBoolean rollbackDone = new AtomicBoolean();
+          try (MessageConsumer consumer = consumerSession.createConsumer(destination)) {
+            consumer.setMessageListener(
+                new MessageListener() {
+                  @Override
+                  public void onMessage(Message message) {
+                    if (error.get() != null) {
+                      log.info("ignoring error on message receive {}", message);
+                      return;
+                    }
+                    log.info("Received message {}", message);
+
+                    try {
+                      if (message.getBody(String.class).equals("commit")) {
+                        log.info("commit!");
+                        consumerSession.commit();
+                        commitDone.set(true);
+                      } else if (message.getBody(String.class).equals("rollback")) {
+                        if (rollbackDone.compareAndSet(false, true)) {
+                          log.info("rollback!");
+                          consumerSession.rollback();
+                        }
+                      } else {
+                        received.add(message);
+                      }
+                    } catch (Exception err) {
+                      log.info("Error", err);
+                      error.set(err);
+                    }
+                  }
+                });
+
+            try (Session producerSession = connection.createSession();
+                MessageProducer producer = producerSession.createProducer(destination); ) {
+
+              producer.send(producerSession.createTextMessage("foo"));
+
+              // verify that the consumer is able to receive the messages
+              Awaitility.await().until(() -> !received.isEmpty());
+              received.clear();
+
+              // rollback
+              producer.send(producerSession.createTextMessage("rollback"));
+              Awaitility.await().until(() -> rollbackDone.get());
+
+              // receive the message again
+              Awaitility.await().until(() -> !received.isEmpty());
+              received.clear();
+
+              producer.send(producerSession.createTextMessage("commit"));
+              Awaitility.await().until(() -> commitDone.get());
 
               // verify no message is received anymore
               Awaitility.await().during(4, TimeUnit.SECONDS).until(() -> received.isEmpty());


### PR DESCRIPTION
The JMS spec does not prevent session.commit()/session.rollback() to be executed in inside a MessageListener.
The TCK does not make any assertions about this possible behaviour.

Modifications:
- allow commit()/rollback() to be executed on a listener
- add tests
- ensure the `unackedMessages` is properly synchronised

Fixes #63