### PR TITLE
Enhance support for Partitioned Topics about Server-side filters and QueueBrowser

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/CompositeEnumeration.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/CompositeEnumeration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public final class CompositeEnumeration implements Enumeration {
+  private final List<? extends Enumeration> enumerations;
+  private int currentEnumeration = 0;
+  private Enumeration current;
+
+  public CompositeEnumeration(List<? extends Enumeration> enumerations) {
+    this.enumerations = enumerations;
+    if (enumerations.isEmpty()) {
+      current = null;
+      currentEnumeration = -1;
+    } else {
+      startEnumeration(0);
+    }
+  }
+
+  private void startEnumeration(int n) {
+    if (n == enumerations.size()) {
+      currentEnumeration = -1;
+      current = null;
+    } else {
+      currentEnumeration = n;
+      this.current = enumerations.get(n);
+      skipEmpty();
+    }
+  }
+
+  private void skipEmpty() {
+    while (!current.hasMoreElements()) {
+      currentEnumeration++;
+      if (currentEnumeration == enumerations.size()) {
+        currentEnumeration = -1;
+        current = null;
+        break;
+      }
+      this.current = enumerations.get(currentEnumeration);
+    }
+  }
+
+  @Override
+  public synchronized boolean hasMoreElements() {
+    return currentEnumeration >= 0;
+  }
+
+  @Override
+  public synchronized Object nextElement() {
+    if (current == null) {
+      throw new NoSuchElementException();
+    }
+    Object next = current.nextElement();
+    if (!current.hasMoreElements()) {
+      startEnumeration(currentEnumeration + 1);
+    }
+    return next;
+  }
+}

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -1245,6 +1245,8 @@ public class PulsarConnectionFactory
         }
       }
       return readers;
+    } catch (PulsarAdminException.NotFoundException err) {
+      return Collections.emptyList();
     } catch (PulsarAdminException err) {
       throw Utils.handleException(err);
     }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/CompositeEnumerationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/CompositeEnumerationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+
+public class CompositeEnumerationTest {
+
+  static List<String> LIST1 = Arrays.asList("a", "b", "c");
+  static List<String> LIST2 = Arrays.asList("d", "e", "f");
+  static List<String> LIST3 = Arrays.asList("g", "h", "i");
+
+  @Test
+  public void testEmpty() {
+    CompositeEnumeration empty = new CompositeEnumeration(Collections.emptyList());
+    assertFalse(empty.hasMoreElements());
+    assertThrows(NoSuchElementException.class, () -> empty.nextElement());
+  }
+
+  @Test
+  public void testWrapEmpty() {
+    List<Enumeration> list = new ArrayList<>();
+    list.add(Collections.emptyEnumeration());
+    CompositeEnumeration empty = new CompositeEnumeration(list);
+    assertFalse(empty.hasMoreElements());
+    assertThrows(NoSuchElementException.class, () -> empty.nextElement());
+  }
+
+  @Test
+  public void testWrap2Empty() {
+    List<Enumeration> list = new ArrayList<>();
+    list.add(Collections.emptyEnumeration());
+    list.add(Collections.emptyEnumeration());
+    CompositeEnumeration empty = new CompositeEnumeration(list);
+    assertFalse(empty.hasMoreElements());
+    assertThrows(NoSuchElementException.class, () -> empty.nextElement());
+  }
+
+  @Test
+  public void testWrap3Empty() {
+    List<Enumeration> list = new ArrayList<>();
+    list.add(Collections.emptyEnumeration());
+    list.add(Collections.emptyEnumeration());
+    list.add(Collections.emptyEnumeration());
+    CompositeEnumeration empty = new CompositeEnumeration(list);
+    assertFalse(empty.hasMoreElements());
+    assertThrows(NoSuchElementException.class, () -> empty.nextElement());
+  }
+
+  @Test
+  public void testWrapSingle() {
+    List<Enumeration> list = new ArrayList<>();
+    list.add(Collections.enumeration(LIST1));
+    CompositeEnumeration e = new CompositeEnumeration(list);
+    assertEquals(LIST1, scan(e));
+  }
+
+  @Test
+  public void testWrap2() {
+    List<Enumeration> list = new ArrayList<>();
+    list.add(Collections.enumeration(LIST1));
+    list.add(Collections.enumeration(LIST2));
+    CompositeEnumeration e = new CompositeEnumeration(list);
+    List<String> concat = new ArrayList<>();
+    concat.addAll(LIST1);
+    concat.addAll(LIST2);
+    assertEquals(concat, scan(e));
+  }
+
+  @Test
+  public void testWrap3() {
+    List<Enumeration> list = new ArrayList<>();
+    list.add(Collections.enumeration(LIST1));
+    list.add(Collections.enumeration(LIST2));
+    list.add(Collections.enumeration(LIST3));
+    CompositeEnumeration e = new CompositeEnumeration(list);
+    List<String> concat = new ArrayList<>();
+    concat.addAll(LIST1);
+    concat.addAll(LIST2);
+    concat.addAll(LIST3);
+    assertEquals(concat, scan(e));
+  }
+
+  @Test
+  public void testWrapEmptyMiddle() {
+    List<Enumeration> list = new ArrayList<>();
+    list.add(Collections.enumeration(LIST1));
+    list.add(Collections.enumeration(Collections.EMPTY_LIST));
+    list.add(Collections.enumeration(LIST3));
+    CompositeEnumeration e = new CompositeEnumeration(list);
+    List<String> concat = new ArrayList<>();
+    concat.addAll(LIST1);
+    concat.addAll(LIST3);
+    assertEquals(concat, scan(e));
+  }
+
+  private static List<String> scan(Enumeration e) {
+    List<String> result = new ArrayList<>();
+    while (e.hasMoreElements()) {
+      result.add((String) e.nextElement());
+    }
+    assertThrows(NoSuchElementException.class, () -> e.nextElement());
+    return result;
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/QueueTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/QueueTest.java
@@ -272,10 +272,38 @@ public class QueueTest {
             assertNull(consumer1.receive(1000));
           }
 
-          // browse a brand new empty queue
-          Queue destinationEmpty =
+          // browse a brand new empty (non existing) queue
+          Queue destinationEmptyNonExisting =
               session.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+          try (QueueBrowser browser = session.createBrowser(destinationEmptyNonExisting)) {
+            Enumeration en = browser.getEnumeration();
+            assertFalse(en.hasMoreElements());
+            try {
+              en.nextElement();
+              fail("should throw NoSuchElementException");
+            } catch (NoSuchElementException expected) {
+            }
+          }
+
+          // browse a brand new empty queue
+          String name = "persistent://public/default/test-" + UUID.randomUUID();
+          cluster.getService().getAdminClient().topics().createNonPartitionedTopic(name);
+          Queue destinationEmpty = session.createQueue(name);
           try (QueueBrowser browser = session.createBrowser(destinationEmpty)) {
+            Enumeration en = browser.getEnumeration();
+            assertFalse(en.hasMoreElements());
+            try {
+              en.nextElement();
+              fail("should throw NoSuchElementException");
+            } catch (NoSuchElementException expected) {
+            }
+          }
+
+          // browse a brand new empty partitioned queue
+          String namePartitioned = "persistent://public/default/test-" + UUID.randomUUID();
+          cluster.getService().getAdminClient().topics().createPartitionedTopic(namePartitioned, 4);
+          Queue destinationEmptyPartitioned = session.createQueue(name);
+          try (QueueBrowser browser = session.createBrowser(destinationEmptyPartitioned)) {
             Enumeration en = browser.getEnumeration();
             assertFalse(en.hasMoreElements());
             try {


### PR DESCRIPTION
This patch adds support for:
- downloading server-side filters on the client (to support batched messages with partially matching entries) for partitioned topics
- partitioned-topics on QueueBrowser
- downloading server-side filters in case of QueueBrowser