### PR TITLE
Admin CLI Extensions: support for virtual destinations and for partitioned topics

### DIFF
--- a/pulsar-jms-admin-ext/src/main/java/com/datastax/oss/pulsar/jms/cli/BaseCommand.java
+++ b/pulsar-jms-admin-ext/src/main/java/com/datastax/oss/pulsar/jms/cli/BaseCommand.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.pulsar.jms.cli;
 
 import com.datastax.oss.pulsar.jms.PulsarConnectionFactory;
+import com.datastax.oss.pulsar.jms.PulsarJMSContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
@@ -25,7 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.jms.JMSContext;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.admin.cli.extensions.CommandExecutionContext;
 import org.apache.pulsar.admin.cli.extensions.CustomCommand;
@@ -87,7 +87,7 @@ abstract class BaseCommand implements CustomCommand {
 
   private ArrayList<AutoCloseable> closeables = new ArrayList<>();
   protected PulsarConnectionFactory factory;
-  protected JMSContext context;
+  protected PulsarJMSContext context;
 
   protected void println(String template, Object... parameters) {
     System.out.println(MessageFormatter.arrayFormat(template, parameters).getMessage());
@@ -142,12 +142,12 @@ abstract class BaseCommand implements CustomCommand {
     }
   }
 
-  protected JMSContext getContext() throws Exception {
+  protected PulsarJMSContext getContext() throws Exception {
     if (context != null) {
       return context;
     }
     PulsarConnectionFactory factory = getFactory();
-    context = factory.createContext();
+    context = (PulsarJMSContext) factory.createContext();
     closeables.add(context);
     return context;
   }

--- a/pulsar-jms-admin-ext/src/main/java/com/datastax/oss/pulsar/jms/cli/TopicBaseCommand.java
+++ b/pulsar-jms-admin-ext/src/main/java/com/datastax/oss/pulsar/jms/cli/TopicBaseCommand.java
@@ -15,9 +15,9 @@
  */
 package com.datastax.oss.pulsar.jms.cli;
 
+import com.datastax.oss.pulsar.jms.PulsarDestination;
 import java.util.Arrays;
 import java.util.List;
-import javax.jms.Destination;
 import org.apache.pulsar.admin.cli.extensions.ParameterDescriptor;
 import org.apache.pulsar.admin.cli.extensions.ParameterType;
 
@@ -41,7 +41,7 @@ abstract class TopicBaseCommand extends BaseCommand {
             .build());
   }
 
-  protected Destination getDestination(boolean requireTopic) throws Exception {
+  protected PulsarDestination getDestination(boolean requireTopic) throws Exception {
     String destination = getStringParameter("--destination", "");
     String destinationType = getStringParameter("--destination-type", "queue");
     switch (destinationType) {
@@ -50,9 +50,9 @@ abstract class TopicBaseCommand extends BaseCommand {
           throw new IllegalArgumentException(
               "createSharedDurableConsumer is available only for JMS Topics, use -t topic");
         }
-        return getContext().createQueue(destination);
+        return (PulsarDestination) getContext().createQueue(destination);
       case "topic":
-        return getContext().createTopic(destination);
+        return (PulsarDestination) getContext().createTopic(destination);
       default:
         throw new IllegalArgumentException("Invalid destination type " + destinationType);
     }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarDestination.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarDestination.java
@@ -100,7 +100,7 @@ public abstract class PulsarDestination implements Destination {
     return destinations;
   }
 
-  protected PulsarDestination createSameType(String topicName) throws InvalidDestinationException {
+  public PulsarDestination createSameType(String topicName) throws InvalidDestinationException {
     throw new InvalidDestinationException(
         "Multi topic syntax is not allowed " + "for this kind of destination (" + getClass() + ")");
   }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueue.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueue.java
@@ -42,7 +42,7 @@ public final class PulsarQueue extends PulsarDestination implements Queue {
   }
 
   @Override
-  protected PulsarDestination createSameType(String topicName) throws InvalidDestinationException {
+  public PulsarDestination createSameType(String topicName) throws InvalidDestinationException {
     return new PulsarQueue(topicName);
   }
 

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTopic.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTopic.java
@@ -47,7 +47,7 @@ public final class PulsarTopic extends PulsarDestination implements Topic {
   }
 
   @Override
-  protected PulsarDestination createSameType(String topicName) throws InvalidDestinationException {
+  public PulsarDestination createSameType(String topicName) throws InvalidDestinationException {
     return new PulsarTopic(topicName);
   }
 

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/TopicDiscoveryUtils.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/TopicDiscoveryUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.LookupService;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+
+@Slf4j
+public class TopicDiscoveryUtils {
+
+  public static List<String> discoverTopicsByPattern(String regex, PulsarClient client, int timeout)
+      throws Exception {
+    TopicName destination = TopicName.get(regex);
+    NamespaceName namespaceName = destination.getNamespaceObject();
+
+    LookupService lookup = ((PulsarClientImpl) client).getLookup();
+    List<String> list =
+        lookup
+            .getTopicsUnderNamespace(namespaceName, CommandGetTopicsOfNamespace.Mode.PERSISTENT)
+            .get(timeout, TimeUnit.MILLISECONDS);
+    return topicsPatternFilter(list, Pattern.compile(regex));
+  }
+
+  // get topics that match 'topicsPattern' from original topics list
+  // return result should contain only topic names, without partition part
+  public static List<String> topicsPatternFilter(List<String> original, Pattern topicsPattern) {
+    // taken from Pulsar 2.10.x
+    // https://github.com/datastax/pulsar/blob/6bc7cf8d7d5b2d5b5e7c5b93c820aa53319e500a/
+    // pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java#L586
+    final Pattern shortenedTopicsPattern =
+        topicsPattern.toString().contains("://")
+            ? Pattern.compile(topicsPattern.toString().split("\\:\\/\\/")[1])
+            : topicsPattern;
+
+    return original
+        .stream()
+        .map(TopicName::get)
+        .map(TopicName::toString)
+        .filter(topic -> shortenedTopicsPattern.matcher(topic.split("\\:\\/\\/")[1]).matches())
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
Modifications to Pulsar Admin Extensions:
- support Virtual Destinations: `multi: `and `regex:`  destinations
- handle partitioned topics

`pulsar-admin jms describe multi:topic1,topic2`

`pulsar-admin jms describe regex:pattern`