### PR TITLE
JMSPriority - POC   implementation using side topics (with explicit Consumer creation) - DO NOT MERGE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <!-- waiting for a Apache Pulsar 2.11.0 release, in the meantime we use DataStax Luna Streaming
          that is a fork of Apache Pulsar  -->
     <pulsar.groupId>com.datastax.oss</pulsar.groupId>
-    <pulsar.version>2.10.2.1-SNAPSHOT</pulsar.version>
+    <pulsar.version>2.10.1.5</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <!-- waiting for a Apache Pulsar 2.11.0 release, in the meantime we use DataStax Luna Streaming
          that is a fork of Apache Pulsar  -->
     <pulsar.groupId>com.datastax.oss</pulsar.groupId>
-    <pulsar.version>2.10.1.5</pulsar.version>
+    <pulsar.version>2.10.2.1-SNAPSHOT</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -350,6 +350,9 @@ public class JMSFilter implements EntryFilter {
                 // cannot decode priority, not a big deal as it is not supported in Pulsar
                 return Message.DEFAULT_PRIORITY;
               }
+            } else {
+              // we are not setting JMSPriority if it is the default value
+              return Message.DEFAULT_PRIORITY;
             }
           }
         case "JMSDeliveryMode":

--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -97,8 +97,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.datastax.oss.pulsar.jms.PulsarConnectionFactory;
+import com.datastax.oss.pulsar.jms.PulsarJMSConsumer;
 import com.datastax.oss.pulsar.jms.PulsarMessageConsumer;
 import com.datastax.oss.pulsar.jms.shaded.org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import java.nio.charset.StandardCharsets;
@@ -157,8 +158,7 @@ public class DockerTest {
           context3.createProducer().setProperty("keepMessage", true).send(topic, "keepMe");
 
           assertEquals("keepMe", consumerWithSelector.receiveBody(String.class));
-          PulsarMessageConsumer.PulsarJMSConsumer pulsarJMSConsumer =
-              (PulsarMessageConsumer.PulsarJMSConsumer) consumerWithSelector;
+          PulsarJMSConsumer pulsarJMSConsumer = (PulsarJMSConsumer) consumerWithSelector;
           PulsarMessageConsumer inner = pulsarJMSConsumer.asPulsarMessageConsumer();
 
           if (useServerSideFiltering) {

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -113,8 +113,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/ConsumerConfiguration.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/ConsumerConfiguration.java
@@ -29,11 +29,10 @@ import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
 final class ConsumerConfiguration {
 
   static ConsumerConfiguration DEFAULT =
-      new ConsumerConfiguration(Collections.emptyMap(), null, null, null, null, null);
+      new ConsumerConfiguration(Collections.emptyMap(), null, null, null, null);
 
   private final Map<String, Object> consumerConfiguration;
   private Schema<?> consumerSchema;
-  private Boolean emulateJMSPriority;
   private DeadLetterPolicy deadLetterPolicy;
   private RedeliveryBackoff negativeAckRedeliveryBackoff;
   private RedeliveryBackoff ackTimeoutRedeliveryBackoff;
@@ -41,13 +40,11 @@ final class ConsumerConfiguration {
   ConsumerConfiguration(
       Map<String, Object> consumerConfiguration,
       Schema<?> consumerSchema,
-      Boolean emulateJMSPriority,
       DeadLetterPolicy deadLetterPolicy,
       RedeliveryBackoff negativeAckRedeliveryBackoff,
       RedeliveryBackoff ackTimeoutRedeliveryBackoff) {
     this.consumerConfiguration = Objects.requireNonNull(consumerConfiguration);
     this.consumerSchema = consumerSchema;
-    this.emulateJMSPriority = emulateJMSPriority;
     this.deadLetterPolicy = deadLetterPolicy;
     this.negativeAckRedeliveryBackoff = negativeAckRedeliveryBackoff;
     this.ackTimeoutRedeliveryBackoff = ackTimeoutRedeliveryBackoff;
@@ -73,10 +70,6 @@ final class ConsumerConfiguration {
     return ackTimeoutRedeliveryBackoff;
   }
 
-  public Boolean isEmulateJMSPriority() {
-    return emulateJMSPriority;
-  }
-
   ConsumerConfiguration applyDefaults(ConsumerConfiguration defaultConsumerConfiguration) {
     Map<String, Object> mergedConsumerConfiguration = new HashMap<>();
     if (defaultConsumerConfiguration.consumerConfiguration != null) {
@@ -88,10 +81,6 @@ final class ConsumerConfiguration {
     }
     Schema<?> mergedConsumerSchema =
         consumerSchema != null ? consumerSchema : defaultConsumerConfiguration.consumerSchema;
-    Boolean mergedEmulateJMSPriority =
-        emulateJMSPriority != null
-            ? emulateJMSPriority
-            : defaultConsumerConfiguration.emulateJMSPriority;
     DeadLetterPolicy mergedDeadLetterPolicy =
         deadLetterPolicy != null ? deadLetterPolicy : defaultConsumerConfiguration.deadLetterPolicy;
     RedeliveryBackoff mergedNegativeAckRedeliveryBackoff =
@@ -106,7 +95,6 @@ final class ConsumerConfiguration {
     return new ConsumerConfiguration(
         mergedConsumerConfiguration,
         mergedConsumerSchema,
-        mergedEmulateJMSPriority,
         mergedDeadLetterPolicy,
         mergedNegativeAckRedeliveryBackoff,
         mergedAckTimeoutRedeliveryBackoff);
@@ -119,7 +107,6 @@ final class ConsumerConfiguration {
     }
     consumerConfigurationM = Utils.deepCopyMap(consumerConfigurationM);
 
-    boolean emulateJMSPriority = false;
     Schema<?> consumerSchema = null;
     Map<String, Object> consumerConfiguration = Collections.emptyMap();
     DeadLetterPolicy deadLetterPolicy = null;
@@ -140,12 +127,6 @@ final class ConsumerConfiguration {
         }
       }
 
-      if (consumerConfiguration.containsKey("emulateJMSPriority")) {
-        emulateJMSPriority =
-            Boolean.parseBoolean(
-                getAndRemoveString("emulateJMSPriority", "false", consumerConfiguration));
-      }
-
       deadLetterPolicy = getAndRemoveDeadLetterPolicy(consumerConfiguration);
       negativeAckRedeliveryBackoff =
           getAndRemoveRedeliveryBackoff("negativeAckRedeliveryBackoff", consumerConfiguration);
@@ -155,7 +136,6 @@ final class ConsumerConfiguration {
     return new ConsumerConfiguration(
         consumerConfiguration,
         consumerSchema,
-        emulateJMSPriority,
         deadLetterPolicy,
         negativeAckRedeliveryBackoff,
         ackTimeoutRedeliveryBackoff);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/IPulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/IPulsarMessageConsumer.java
@@ -16,10 +16,14 @@
 package com.datastax.oss.pulsar.jms;
 
 import javax.jms.JMSConsumer;
+import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.QueueReceiver;
 import javax.jms.TopicSubscriber;
 
 public interface IPulsarMessageConsumer extends MessageConsumer, TopicSubscriber, QueueReceiver {
   JMSConsumer asJMSConsumer();
+
+  Message receiveWithTimeoutAndValidateType(long timeout, Class expectedType) throws JMSException;
 }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/IPulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/IPulsarMessageConsumer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import javax.jms.JMSConsumer;
+import javax.jms.MessageConsumer;
+import javax.jms.QueueReceiver;
+import javax.jms.TopicSubscriber;
+
+public interface IPulsarMessageConsumer extends MessageConsumer, TopicSubscriber, QueueReceiver {
+  JMSConsumer asJMSConsumer();
+}

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -117,6 +117,7 @@ public class PulsarConnectionFactory
   private transient boolean enableClientSideEmulation = false;
   private transient boolean transactionsStickyPartitions = false;
   private transient boolean useServerSideFiltering = false;
+  private transient boolean emulateJMSPriority = false;
   private transient boolean forceDeleteTemporaryDestinations = false;
   private transient boolean useExclusiveSubscriptionsForSimpleConsumers = false;
   private transient boolean acknowledgeRejectedMessages = false;
@@ -214,7 +215,7 @@ public class PulsarConnectionFactory
     return copy;
   }
 
-  private synchronized ConsumerConfiguration getConsumerConfiguration(
+  synchronized ConsumerConfiguration getConsumerConfiguration(
       ConsumerConfiguration overrideConsumerConfiguration) {
     if (overrideConsumerConfiguration == null) {
       return defaultConsumerConfiguration;

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSConsumer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import javax.jms.JMSConsumer;
+import javax.jms.JMSRuntimeException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+public class PulsarJMSConsumer implements JMSConsumer {
+
+  private final IPulsarMessageConsumer pulsarMessageConsumer;
+
+  public PulsarJMSConsumer(IPulsarMessageConsumer pulsarMessageConsumer) {
+    this.pulsarMessageConsumer = pulsarMessageConsumer;
+  }
+
+  public IPulsarMessageConsumer asPulsarMessageConsumer() {
+    return pulsarMessageConsumer;
+  }
+
+  @Override
+  public String getMessageSelector() {
+    return Utils.runtimeException(() -> pulsarMessageConsumer.getMessageSelector());
+  }
+
+  @Override
+  public MessageListener getMessageListener() throws JMSRuntimeException {
+    return Utils.runtimeException(() -> pulsarMessageConsumer.getMessageListener());
+  }
+
+  @Override
+  public void setMessageListener(MessageListener listener) throws JMSRuntimeException {
+    Utils.runtimeException(() -> pulsarMessageConsumer.setMessageListener(listener));
+  }
+
+  @Override
+  public Message receive() {
+    return Utils.runtimeException(() -> pulsarMessageConsumer.receive());
+  }
+
+  @Override
+  public Message receive(long timeout) {
+    return Utils.runtimeException(() -> pulsarMessageConsumer.receive(timeout));
+  }
+
+  @Override
+  public Message receiveNoWait() {
+    return Utils.runtimeException(() -> pulsarMessageConsumer.receiveNoWait());
+  }
+
+  @Override
+  public void close() {
+    Utils.runtimeException(() -> pulsarMessageConsumer.close());
+  }
+
+  @Override
+  public <T> T receiveBody(Class<T> c) {
+    return Utils.runtimeException(
+        () -> {
+          Message msg = pulsarMessageConsumer.receiveWithTimeoutAndValidateType(Long.MAX_VALUE, c);
+          return msg == null ? null : msg.getBody(c);
+        });
+  }
+
+  @Override
+  public <T> T receiveBody(Class<T> c, long timeout) {
+    return Utils.runtimeException(
+        () -> {
+          Message msg = pulsarMessageConsumer.receiveWithTimeoutAndValidateType(timeout, c);
+          return msg == null ? null : msg.getBody(c);
+        });
+  }
+
+  @Override
+  public <T> T receiveBodyNoWait(Class<T> c) {
+    return Utils.runtimeException(
+        () -> {
+          Message msg = pulsarMessageConsumer.receiveWithTimeoutAndValidateType(1, c);
+          return msg == null ? null : msg.getBody(c);
+        });
+  }
+}

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -28,7 +28,6 @@ import javax.jms.IllegalStateException;
 import javax.jms.InvalidDestinationException;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSException;
-import javax.jms.JMSRuntimeException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageFormatException;
@@ -282,7 +281,8 @@ public class PulsarMessageConsumer implements IPulsarMessageConsumer {
     return receiveWithTimeoutAndValidateType(timeout, null);
   }
 
-  private synchronized Message receiveWithTimeoutAndValidateType(long timeout, Class expectedType)
+  @Override
+  public synchronized Message receiveWithTimeoutAndValidateType(long timeout, Class expectedType)
       throws JMSException {
     checkNotClosed();
     if (listener != null) {
@@ -582,7 +582,7 @@ public class PulsarMessageConsumer implements IPulsarMessageConsumer {
   }
 
   public JMSConsumer asJMSConsumer() {
-    return new PulsarJMSConsumer();
+    return new PulsarJMSConsumer(this);
   }
 
   synchronized void acknowledge(
@@ -719,75 +719,5 @@ public class PulsarMessageConsumer implements IPulsarMessageConsumer {
 
   public long getSkippedMessages() {
     return skippedMessages.get();
-  }
-
-  public class PulsarJMSConsumer implements JMSConsumer {
-
-    public PulsarMessageConsumer asPulsarMessageConsumer() {
-      return PulsarMessageConsumer.this;
-    }
-
-    @Override
-    public String getMessageSelector() {
-      return Utils.runtimeException(() -> PulsarMessageConsumer.this.getMessageSelector());
-    }
-
-    @Override
-    public MessageListener getMessageListener() throws JMSRuntimeException {
-      return Utils.runtimeException(() -> PulsarMessageConsumer.this.getMessageListener());
-    }
-
-    @Override
-    public void setMessageListener(MessageListener listener) throws JMSRuntimeException {
-      Utils.runtimeException(() -> PulsarMessageConsumer.this.setMessageListener(listener));
-    }
-
-    @Override
-    public Message receive() {
-      return Utils.runtimeException(() -> PulsarMessageConsumer.this.receive());
-    }
-
-    @Override
-    public Message receive(long timeout) {
-      return Utils.runtimeException(() -> PulsarMessageConsumer.this.receive(timeout));
-    }
-
-    @Override
-    public Message receiveNoWait() {
-      return Utils.runtimeException(() -> PulsarMessageConsumer.this.receiveNoWait());
-    }
-
-    @Override
-    public void close() {
-      Utils.runtimeException(() -> PulsarMessageConsumer.this.close());
-    }
-
-    @Override
-    public <T> T receiveBody(Class<T> c) {
-      return Utils.runtimeException(
-          () -> {
-            Message msg =
-                PulsarMessageConsumer.this.receiveWithTimeoutAndValidateType(Long.MAX_VALUE, c);
-            return msg == null ? null : msg.getBody(c);
-          });
-    }
-
-    @Override
-    public <T> T receiveBody(Class<T> c, long timeout) {
-      return Utils.runtimeException(
-          () -> {
-            Message msg = PulsarMessageConsumer.this.receiveWithTimeoutAndValidateType(timeout, c);
-            return msg == null ? null : msg.getBody(c);
-          });
-    }
-
-    @Override
-    public <T> T receiveBodyNoWait(Class<T> c) {
-      return Utils.runtimeException(
-          () -> {
-            Message msg = PulsarMessageConsumer.this.receiveWithTimeoutAndValidateType(1, c);
-            return msg == null ? null : msg.getBody(c);
-          });
-    }
   }
 }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -34,10 +34,8 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageFormatException;
 import javax.jms.MessageListener;
 import javax.jms.Queue;
-import javax.jms.QueueReceiver;
 import javax.jms.Session;
 import javax.jms.Topic;
-import javax.jms.TopicSubscriber;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -46,7 +44,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 
 @Slf4j
-public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, QueueReceiver {
+public class PulsarMessageConsumer implements IPulsarMessageConsumer {
 
   final String subscriptionName;
   private final PulsarSession session;

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -1195,7 +1195,7 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
     }
     session.executeCriticalOperation(
         () -> {
-          Producer<byte[]> producer = session.getProducerForDestination(defaultDestination);
+          Producer<byte[]> producer = session.getProducerForDestination(defaultDestination, message.getJMSPriority());
           message.setJMSDestination(defaultDestination);
           PulsarMessage pulsarMessage = prepareMessageForSend(message);
           final TypedMessageBuilder<byte[]> typedMessageBuilder;
@@ -1235,7 +1235,7 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
     }
     session.executeCriticalOperation(
         () -> {
-          Producer<byte[]> producer = session.getProducerForDestination(defaultDestination);
+          Producer<byte[]> producer = session.getProducerForDestination(defaultDestination, message.getJMSPriority());
           message.setJMSDestination(defaultDestination);
           PulsarMessage pulsarMessage = prepareMessageForSend(message);
           CompletionListener endActivityCompletionListener =

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarPriorityAwareMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarPriorityAwareMessageConsumer.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import java.util.List;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.Queue;
+import javax.jms.Topic;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PulsarPriorityAwareMessageConsumer implements IPulsarMessageConsumer {
+
+  private final List<PulsarMessageConsumer> consumers;
+  private final String selector;
+  private final Status status;
+
+  public PulsarPriorityAwareMessageConsumer(List<PulsarMessageConsumer> consumers, String selector)
+      throws JMSException {
+    this.consumers = consumers;
+    this.selector = selector;
+    this.status = new Status(consumers.size());
+  }
+
+  @Override
+  public synchronized String getMessageSelector() throws JMSException {
+    checkNotClosed();
+    return selector;
+  }
+
+  @Override
+  public synchronized MessageListener getMessageListener() throws JMSException {
+    return getFirst().getMessageListener();
+  }
+
+  private PulsarMessageConsumer getFirst() {
+    return consumers.get(0);
+  }
+
+  synchronized void checkNotClosed() throws JMSException {
+    getFirst().checkNotClosed();
+  }
+
+  @Override
+  public synchronized void setMessageListener(MessageListener listener) throws JMSException {
+    checkNotClosed();
+    for (MessageConsumer consumer : consumers) {
+      consumer.setMessageListener(listener);
+    }
+  }
+
+  static final class Status {
+    private final int maxConsumers;
+    private int countCurrentConsumer;
+    private int currentConsumer;
+
+    Status(int maxConsumers) {
+      this.maxConsumers = maxConsumers;
+    }
+
+    synchronized void matched() {
+      countCurrentConsumer++;
+      if (countCurrentConsumer >= 10) {
+        currentConsumer = 0;
+        countCurrentConsumer = 0;
+      }
+    }
+
+    synchronized void notMatched() {
+      currentConsumer++;
+      if (currentConsumer >= maxConsumers) {
+        currentConsumer = 0;
+      }
+      countCurrentConsumer = 0;
+    }
+
+    synchronized int currentConsumer() {
+      return currentConsumer;
+    }
+  }
+
+  @Override
+  public Message receive() throws JMSException {
+    while (true) {
+      PulsarMessageConsumer pulsarMessageConsumer = consumers.get(status.currentConsumer());
+      Message message = pulsarMessageConsumer.receive(1000);
+      if (message != null) {
+        status.matched();
+        return message;
+      } else {
+        status.notMatched();
+      }
+    }
+  }
+
+  @Override
+  public Message receive(long timeout) throws JMSException {
+    long start = System.currentTimeMillis();
+    while (System.currentTimeMillis() - start < timeout) {
+      PulsarMessageConsumer pulsarMessageConsumer = consumers.get(status.currentConsumer());
+      Message message = pulsarMessageConsumer.receive(1);
+      if (message != null) {
+        status.matched();
+        return message;
+      } else {
+        status.notMatched();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Message receiveNoWait() throws JMSException {
+    PulsarMessageConsumer pulsarMessageConsumer = consumers.get(status.currentConsumer());
+    Message message = pulsarMessageConsumer.receive(1);
+    if (message != null) {
+      status.matched();
+      return message;
+    } else {
+      status.notMatched();
+    }
+    return null;
+  }
+
+  @Override
+  public synchronized void close() throws JMSException {
+    JMSException firstError = null;
+    for (PulsarMessageConsumer consumer : consumers) {
+      try {
+        consumer.close();
+      } catch (JMSException err) {
+        if (firstError == null) {
+          firstError = err;
+        } else {
+          firstError.addSuppressed(err);
+        }
+      }
+    }
+    if (firstError != null) {
+      throw firstError;
+    }
+  }
+
+  @Override
+  public String toString() {
+    PulsarMessageConsumer first = getFirst();
+    return "PulsarPriorityAwareMessageConsumer{subscriptionName="
+        + first.subscriptionName
+        + ", destination="
+        + first.getDestination()
+        + '}';
+  }
+
+  @Override
+  public synchronized Topic getTopic() throws JMSException {
+    checkNotClosed();
+    return getFirst().getTopic();
+  }
+
+  @Override
+  public synchronized Queue getQueue() throws JMSException {
+    checkNotClosed();
+    return getFirst().getQueue();
+  }
+
+  /**
+   * Gets the {@code NoLocal} attribute for this subscriber. The default value for this attribute is
+   * false.
+   *
+   * @return true if locally published messages are being inhibited
+   * @throws JMSException if the JMS provider fails to get the {@code NoLocal} attribute for this
+   *     topic subscriber due to some internal error.
+   */
+  @Override
+  public synchronized boolean getNoLocal() throws JMSException {
+    checkNotClosed();
+    return getFirst().getNoLocal();
+  }
+
+  @Override
+  public JMSConsumer asJMSConsumer() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/BasicServerSideFilterTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/BasicServerSideFilterTest.java
@@ -155,7 +155,8 @@ public class BasicServerSideFilterTest {
 
           // do not set the selector, it will be loaded from the Subscription Properties
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
@@ -170,7 +171,8 @@ public class BasicServerSideFilterTest {
           cluster.getService().getAdminClient().topics().unload(topicName);
 
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
@@ -183,7 +185,8 @@ public class BasicServerSideFilterTest {
 
           // non-existing topic, auto-created
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination2, subscriptionName, null); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination2, subscriptionName, null); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             produce(session, destination2);
@@ -194,8 +197,9 @@ public class BasicServerSideFilterTest {
 
           // non-existing subscription
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(
-                  destination2, subscriptionName + "non-existing", null); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(
+                      destination2, subscriptionName + "non-existing", null); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             produce(session, destination2);
@@ -224,7 +228,8 @@ public class BasicServerSideFilterTest {
           Whitebox.setInternalState(factory, "pulsarAdmin", mockPulsarAdmin);
 
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             produce(session, destination);

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConfigurationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConfigurationTest.java
@@ -74,7 +74,8 @@ public class ConfigurationTest {
         PulsarConnection connection = factory.createConnection();
         PulsarSession session = connection.createSession()) {
       Queue queue = session.createQueue("test" + UUID.randomUUID());
-      try (PulsarMessageConsumer consumer = session.createConsumer(queue); ) {
+      try (PulsarMessageConsumer consumer =
+          (PulsarMessageConsumer) session.createConsumer(queue); ) {
         Consumer<?> pulsarConsumer = consumer.getConsumer();
         assertEquals("the-consumer-name", pulsarConsumer.getConsumerName());
       }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConfigurationTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConfigurationTest.java
@@ -58,7 +58,7 @@ public class ConfigurationTest {
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties);
         PulsarConnection connection = factory.createConnection(); ) {
       PulsarDestination destination = new PulsarQueue("test-" + UUID.randomUUID());
-      Producer<byte[]> producer = factory.getProducerForDestination(destination, false);
+      Producer<byte[]> producer = factory.getProducerForDestination(destination, false, PulsarMessage.DEFAULT_PRIORITY);
       assertEquals("the-name", producer.getProducerName());
     }
   }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JNDITest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JNDITest.java
@@ -89,7 +89,7 @@ public class JNDITest {
         PulsarDestination queue = (PulsarDestination) jndiContext.lookup("queues/" + queueName);
         PulsarDestination topic = (PulsarDestination) jndiContext.lookup("topics/" + topicName);
 
-        Producer<byte[]> producer = factory.getProducerForDestination(queue, false);
+        Producer<byte[]> producer = factory.getProducerForDestination(queue, false, PulsarMessage.DEFAULT_PRIORITY);
         // test that configuration is fully passed
         assertEquals("the-name", producer.getProducerName());
 

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PriorityTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PriorityTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.jms.Connection;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Slf4j
+public class PriorityTest {
+
+  @TempDir public static Path tempDir;
+  private static PulsarCluster cluster;
+
+  @BeforeAll
+  public static void before() throws Exception {
+    cluster = new PulsarCluster(tempDir);
+    cluster.start();
+  }
+
+  @AfterAll
+  public static void after() throws Exception {
+    if (cluster != null) {
+      cluster.close();
+    }
+  }
+
+  @Test
+  public void basicPriorityTest() throws Exception {
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.useServerSideFiltering", true);
+
+    properties.put("consumerConfig", ImmutableMap.of("emulateJMSPriority", true));
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (Connection connection = factory.createConnection()) {
+        connection.start();
+        try (Session session = connection.createSession(); ) {
+          Queue destination =
+              session.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+
+          int numMessages = 100;
+          try (MessageProducer producer = session.createProducer(destination); ) {
+            for (int i = 0; i < numMessages; i++) {
+              TextMessage textMessage = session.createTextMessage("foo-" + i);
+              if (i < numMessages / 2) {
+                // the first messages are lower priority
+                producer.setPriority(1);
+              } else {
+                producer.setPriority(9);
+              }
+              log.info("send {} prio {}", textMessage.getText(), producer.getPriority());
+              producer.send(textMessage);
+            }
+          }
+
+          try (MessageConsumer consumer1 = session.createConsumer(destination); ) {
+            List<TextMessage> received = new ArrayList<>();
+            for (int i = 0; i < numMessages; i++) {
+              TextMessage msg = (TextMessage) consumer1.receive();
+              log.info("got msg {} prio {}", msg.getText(), msg.getJMSPriority());
+              received.add(msg);
+            }
+
+            // no more messages
+            assertNull(consumer1.receiveNoWait());
+
+            // verify that higher priority messages arrived before the others
+            int lastPriority = Integer.MAX_VALUE;
+            for (TextMessage msg : received) {
+              int priority = msg.getJMSPriority();
+              log.info("received {} priority {}", msg.getText(), priority);
+              assertTrue(priority <= lastPriority);
+              lastPriority = priority;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PriorityTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PriorityTest.java
@@ -66,8 +66,7 @@ public class PriorityTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
     properties.put("jms.useServerSideFiltering", true);
-
-    properties.put("consumerConfig", ImmutableMap.of("emulateJMSPriority", true));
+    properties.put("jms.emulateJMSPriority", true);
 
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
       try (Connection connection = factory.createConnection()) {
@@ -122,8 +121,7 @@ public class PriorityTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
     properties.put("jms.useServerSideFiltering", true);
-
-    properties.put("consumerConfig", ImmutableMap.of("emulateJMSPriority", true));
+    properties.put("jms.emulateJMSPriority", true);
 
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
       try (JMSContext context = factory.createContext()) {

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -121,7 +121,7 @@ public abstract class SelectorsTestsBase {
               session.createQueue("persistent://public/default/test-" + UUID.randomUUID());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createConsumer(destination, "lastMessage=TRUE"); ) {
+              (PulsarMessageConsumer) session.createConsumer(destination, "lastMessage=TRUE"); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             assertEquals("lastMessage=TRUE", consumer1.getMessageSelector());
@@ -176,7 +176,7 @@ public abstract class SelectorsTestsBase {
               .createNonPartitionedTopic(destination.getTopicName());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createConsumer(destination, "lastMessage=TRUE"); ) {
+              (PulsarMessageConsumer) session.createConsumer(destination, "lastMessage=TRUE"); ) {
             assertEquals(
                 SubscriptionType.Exclusive,
                 ((PulsarMessageConsumer) consumer1).getSubscriptionType());
@@ -228,7 +228,8 @@ public abstract class SelectorsTestsBase {
               session.createTopic("persistent://public/default/test-" + UUID.randomUUID());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createDurableConsumer(destination, "sub1", "lastMessage=TRUE", false); ) {
+              (PulsarMessageConsumer)
+                  session.createDurableConsumer(destination, "sub1", "lastMessage=TRUE", false); ) {
             assertEquals(
                 SubscriptionType.Exclusive,
                 ((PulsarMessageConsumer) consumer1).getSubscriptionType());
@@ -279,7 +280,8 @@ public abstract class SelectorsTestsBase {
               session.createTopic("persistent://public/default/test-" + UUID.randomUUID());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination, "sub1", "lastMessage=TRUE"); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination, "sub1", "lastMessage=TRUE"); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             assertEquals("lastMessage=TRUE", consumer1.getMessageSelector());
@@ -334,7 +336,7 @@ public abstract class SelectorsTestsBase {
               session.createQueue("persistent://public/default/test-" + UUID.randomUUID());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createConsumer(destination, "keepMessage=TRUE"); ) {
+              (PulsarMessageConsumer) session.createConsumer(destination, "keepMessage=TRUE"); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             assertEquals("keepMessage=TRUE", consumer1.getMessageSelector());
@@ -438,7 +440,8 @@ public abstract class SelectorsTestsBase {
               session.createTopic("persistent://public/default/test-" + UUID.randomUUID());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination, "sub1", "keepMessage=TRUE"); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination, "sub1", "keepMessage=TRUE"); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             assertEquals("keepMessage=TRUE", consumer1.getMessageSelector());
@@ -526,11 +529,10 @@ public abstract class SelectorsTestsBase {
         try (PulsarSession session = connection.createSession(); ) {
           Queue destination =
               session.createQueue("persistent://public/default/test-" + UUID.randomUUID());
-
           try (PulsarMessageConsumer consumer1 =
-                  session.createConsumer(destination, "consumer='one'");
+                  (PulsarMessageConsumer) session.createConsumer(destination, "consumer='one'");
               PulsarMessageConsumer consumer2 =
-                  session.createConsumer(destination, "consumer='two'"); ) {
+                  (PulsarMessageConsumer) session.createConsumer(destination, "consumer='two'"); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             assertEquals("consumer='one'", consumer1.getMessageSelector());
@@ -672,7 +674,8 @@ public abstract class SelectorsTestsBase {
               session.createTopic("persistent://public/default/test-" + UUID.randomUUID());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination, "sub1", "keepMessage=TRUE"); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination, "sub1", "keepMessage=TRUE"); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
             assertEquals("keepMessage=TRUE", consumer1.getMessageSelector());
@@ -793,7 +796,8 @@ public abstract class SelectorsTestsBase {
 
           // do not set the selector, it will be loaded from the Subscription Properties
           try (PulsarMessageConsumer consumer1 =
-              session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
+              (PulsarMessageConsumer)
+                  session.createSharedDurableConsumer(destination, subscriptionName, null); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
@@ -911,7 +915,8 @@ public abstract class SelectorsTestsBase {
           Queue destination = session.createQueue(topicName + ":" + subscriptionName);
 
           // do not set the selector, it will be loaded from the Subscription Properties
-          try (PulsarMessageConsumer consumer1 = session.createConsumer(destination); ) {
+          try (PulsarMessageConsumer consumer1 =
+              (PulsarMessageConsumer) session.createConsumer(destination); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
@@ -1044,7 +1049,7 @@ public abstract class SelectorsTestsBase {
 
           // the final local selector is the subscription selector AND the local selector
           try (PulsarMessageConsumer consumer1 =
-              session.createConsumer(destination, selectorOnClient); ) {
+              (PulsarMessageConsumer) session.createConsumer(destination, selectorOnClient); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
@@ -1140,7 +1145,7 @@ public abstract class SelectorsTestsBase {
               session.createTopic("persistent://public/default/test-" + UUID.randomUUID());
 
           try (PulsarMessageConsumer consumer1 =
-              session.createConsumer(destination, "lastMessage=TRUE"); ) {
+              (PulsarMessageConsumer) session.createConsumer(destination, "lastMessage=TRUE"); ) {
             assertEquals(
                 SubscriptionType.Exclusive,
                 ((PulsarMessageConsumer) consumer1).getSubscriptionType());
@@ -1231,7 +1236,8 @@ public abstract class SelectorsTestsBase {
           Queue destination = session.createQueue(topicName + ":" + subscriptionName);
 
           // do not set the selector, it will be loaded from the Subscription Properties
-          try (PulsarMessageConsumer consumer1 = session.createConsumer(destination); ) {
+          try (PulsarMessageConsumer consumer1 =
+              (PulsarMessageConsumer) session.createConsumer(destination); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
@@ -1298,7 +1304,8 @@ public abstract class SelectorsTestsBase {
           // since 2.0.1 you can set the Subscription name in the JMS Queue Name
           Queue destination = session.createQueue(topicName + ":" + subscriptionName);
 
-          try (PulsarMessageConsumer consumer1 = session.createConsumer(destination, selector); ) {
+          try (PulsarMessageConsumer consumer1 =
+              (PulsarMessageConsumer) session.createConsumer(destination, selector); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SelectorsTestsBase.java
@@ -67,7 +67,7 @@ public abstract class SelectorsTestsBase {
   private static PulsarCluster cluster;
 
   private final boolean useServerSideFiltering;
-  private final boolean enableBatching;
+  protected final boolean enableBatching;
 
   public SelectorsTestsBase(boolean useServerSideFiltering, boolean enableBatching) {
     this.useServerSideFiltering = useServerSideFiltering;
@@ -88,7 +88,7 @@ public abstract class SelectorsTestsBase {
     }
   }
 
-  private Map<String, Object> buildProperties() {
+  protected Map<String, Object> buildProperties() {
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
 

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ServerSideWithoutBatchingTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ServerSideWithoutBatchingTest.java
@@ -15,8 +15,188 @@
  */
 package com.datastax.oss.pulsar.jms;
 
+import com.datastax.oss.pulsar.jms.messages.PulsarTextMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.BatchMessageIdImpl;
+import org.junit.jupiter.api.Test;
+
+import javax.jms.CompletionListener;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.TextMessage;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
 public final class ServerSideWithoutBatchingTest extends SelectorsTestsBase {
   public ServerSideWithoutBatchingTest() {
     super(true, false);
+  }
+
+
+  @Test
+  public void competingOnJMSPriority() throws Exception {
+    Map<String, Object> properties = buildProperties();
+    Map<String, Object> consumerConfig = (Map<String, Object>) properties.get("consumerConfig");
+    consumerConfig.put("receiverQueueSize", 64);
+
+    if (enableBatching) {
+      // ensure that we create batches with more than 1 message
+      Map<String, Object> producerConfig = (Map<String, Object>) properties.get("producerConfig");
+      producerConfig.put("batchingMaxPublishDelayMicros", "1000000");
+      // each batch will contain 5 messages
+      producerConfig.put("batchingMaxMessages", "5");
+    }
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (PulsarConnection connection = factory.createConnection()) {
+        connection.start();
+        try (PulsarSession session = connection.createSession(); ) {
+          Queue destination =
+                  session.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+
+          try (PulsarMessageConsumer consumerSlowLowPriority =
+                       session.createConsumer(destination, "JMSPriority = 4");
+               PulsarMessageConsumer consumerHighPriority =
+                       session.createConsumer(destination, "JMSPriority > 4"); ) {
+            assertEquals(
+                    SubscriptionType.Shared, ((PulsarMessageConsumer) consumerSlowLowPriority).getSubscriptionType());
+            assertEquals("JMSPriority = 4", consumerSlowLowPriority.getMessageSelector());
+            assertEquals(
+                    SubscriptionType.Shared, ((PulsarMessageConsumer) consumerSlowLowPriority).getSubscriptionType());
+            assertEquals("JMSPriority > 4", consumerHighPriority.getMessageSelector());
+
+            List<CompletableFuture<Message>> handles = new ArrayList<>();
+            List<String> expected1 = new CopyOnWriteArrayList<>();
+            List<String> expected2 = new CopyOnWriteArrayList<>();
+            int numMessages = 40_000;
+            try (MessageProducer producer = session.createProducer(destination); ) {
+              for (int i = 0; i < numMessages; i++) {
+                String text = "foo-" + i;
+                TextMessage textMessage = session.createTextMessage(text);
+                if (i < numMessages - 100) {
+                  producer.setPriority(4);
+                  expected1.add(text);
+                } else {
+                  producer.setPriority(8);
+                  expected2.add(text);
+                }
+                CompletableFuture<Message> handle = new CompletableFuture<>();
+                producer.send(
+                        textMessage,
+                        new CompletionListener() {
+                          @Override
+                          public void onCompletion(Message message) {
+                            handle.complete(message);
+                          }
+
+                          @Override
+                          public void onException(Message message, Exception e) {
+                            handle.completeExceptionally(e);
+                          }
+                        });
+                handles.add(handle);
+
+                if (handles.size() % 1000 == 0) {
+                  CompletableFuture.allOf(handles.toArray(new CompletableFuture[0])).get();
+                  handles.clear();
+                  log.info("sent {}...", i);
+                }
+              }
+            }
+
+            CompletableFuture.allOf(handles.toArray(new CompletableFuture[0])).get();
+
+            CompletableFuture<String> thread1Result = new CompletableFuture();
+            Thread thread1 =
+                    new Thread(
+                            () -> {
+                              try {
+                                while (!expected1.isEmpty()) {
+                                  log.info(
+                                          "{} messages left for consumer1", expected1.size());
+                                  PulsarTextMessage textMessage = (PulsarTextMessage) consumerSlowLowPriority.receive();
+                                  log.info(
+                                          "consumerSlowLowPriority received {} {}",
+                                          textMessage.getText(),
+                                          textMessage.getJMSPriority()
+                                  );
+                                  // ensure that we receive the message only ONCE
+                                  assertTrue(expected1.remove(textMessage.getText()));
+
+                                  // ensure that it is a batch message
+                                  assertEquals(
+                                          enableBatching,
+                                          textMessage.getReceivedPulsarMessage().getMessageId()
+                                                  instanceof BatchMessageIdImpl);
+
+                                  Thread.sleep(10000);
+                                }
+                                // no more messages (this also drains some remaining messages to be skipped)
+                                assertNull(consumerSlowLowPriority.receive(1000));
+
+                                thread1Result.complete("");
+                              } catch (Throwable t) {
+                                log.error("error thread1", t);
+                                thread1Result.completeExceptionally(t);
+                              }
+                            });
+
+            CompletableFuture<String> thread2Result = new CompletableFuture();
+            Thread thread2 =
+                    new Thread(
+                            () -> {
+                              try {
+                                while (!expected2.isEmpty()) {
+                                  log.info(
+                                          "{} messages left for consumerHighPriority", expected2.size());
+                                  PulsarTextMessage textMessage = (PulsarTextMessage) consumerHighPriority.receive();
+                                  log.info(
+                                          "consumerHighPriority received {} {}",
+                                          textMessage.getText(),
+                                          textMessage.getJMSPriority());
+                                  // ensure that we receive the message only ONCE
+                                  assertTrue(expected2.remove(textMessage.getText()));
+
+                                  // ensure that it is a batch message
+                                  assertEquals(
+                                          enableBatching,
+                                          textMessage.getReceivedPulsarMessage().getMessageId()
+                                                  instanceof BatchMessageIdImpl);
+                                }
+                                // no more messages (this also drains some remaining messages to be skipped)
+                                assertNull(consumerHighPriority.receive(1000));
+
+                                thread2Result.complete("");
+                              } catch (Throwable t) {
+                                log.error("error thread2", t);
+                                thread2Result.completeExceptionally(t);
+                              }
+                            });
+
+            thread1.start();
+            thread2.start();
+
+            // fail if we don't consume all the high priority messages in a timely fashion
+            // 10 seconds seems bad, but it is only a hard limit, the test should take less than 5 seconds
+            // but CI machines may be slower.
+            thread2Result.get(10, TimeUnit.SECONDS);
+            log.info("COMPLETED HIGH PRIORITY!!!");
+          }
+        }
+      }
+    }
   }
 }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TimeToLiveTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TimeToLiveTest.java
@@ -117,7 +117,8 @@ public class TimeToLiveTest {
 
           // here we are creating the Consumer after Thread.sleep, so when the broker
           // dispatches the messages they are already expired
-          try (PulsarMessageConsumer consumer1 = session.createConsumer(destination); ) {
+          try (PulsarMessageConsumer consumer1 =
+              (PulsarMessageConsumer) session.createConsumer(destination); ) {
             assertEquals(SubscriptionType.Shared, consumer1.getSubscriptionType());
 
             // only foo-1, foo-3, foo-5... can be received
@@ -176,7 +177,8 @@ public class TimeToLiveTest {
           // so one message (receiverQueueSize=1) will be processed on the broker as soon as it has
           // been
           // produced
-          try (PulsarMessageConsumer consumer1 = session.createConsumer(destination); ) {
+          try (PulsarMessageConsumer consumer1 =
+              (PulsarMessageConsumer) session.createConsumer(destination); ) {
             assertEquals(SubscriptionType.Exclusive, consumer1.getSubscriptionType());
 
             try (MessageProducer producer = session.createProducer(destination); ) {

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/VirtualDestinationsConsumerTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/VirtualDestinationsConsumerTest.java
@@ -241,7 +241,8 @@ public class VirtualDestinationsConsumerTest {
           assertEquals(useRegExp, asPulsarDestination.isRegExp());
 
           // do not set the selector, it will be loaded from the Subscription Properties
-          try (PulsarMessageConsumer consumer1 = session.createConsumer(wildcardDestination); ) {
+          try (PulsarMessageConsumer consumer1 =
+              (PulsarMessageConsumer) session.createConsumer(wildcardDestination); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 
@@ -372,7 +373,7 @@ public class VirtualDestinationsConsumerTest {
 
           // do not set the selector, it will be loaded from the Subscription Properties
           try (PulsarMessageConsumer consumer1 =
-              session.createConsumer(wildcardDestination, selector); ) {
+              (PulsarMessageConsumer) session.createConsumer(wildcardDestination, selector); ) {
             assertEquals(
                 SubscriptionType.Shared, ((PulsarMessageConsumer) consumer1).getSubscriptionType());
 

--- a/pulsar-jms/src/test/resources/log4j2.xml
+++ b/pulsar-jms/src/test/resources/log4j2.xml
@@ -30,7 +30,6 @@
     <logger name="org.apache.bookkeeper.mledger" level="info" additivity="true"/>
     <logger name="org.apache.pulsar" level="info" additivity="true"/>
     <logger name="org.apache.pulsar.broker.service.persistent" level="info" additivity="true"/>
-
     <logger name="org.apache.pulsar.client" level="info" additivity="true"/>
     <logger name="org.apache.zookeeper" level="error" additivity="true"/>
     <logger name="org.apache.curator" level="error" additivity="true"/>

--- a/pulsar-jms/src/test/resources/log4j2.xml
+++ b/pulsar-jms/src/test/resources/log4j2.xml
@@ -29,6 +29,9 @@
     <logger name="org.apache.bookkeeper" level="error" additivity="true"/>
     <logger name="org.apache.bookkeeper.mledger" level="info" additivity="true"/>
     <logger name="org.apache.pulsar" level="info" additivity="true"/>
+    <logger name="org.apache.pulsar.broker.service.persistent" level="info" additivity="true"/>
+
+    <logger name="org.apache.pulsar.client" level="info" additivity="true"/>
     <logger name="org.apache.zookeeper" level="error" additivity="true"/>
     <logger name="org.apache.curator" level="error" additivity="true"/>
     <logger name="org.eclipse.jetty" level="error" additivity="true"/>


### PR DESCRIPTION
Modifications:
- introduce a new global configuration flag jms.emulateJMSPriority=true
- priority is not supported while using "RegExp Destinations" (only normal destinations and multi:xxx)
- on the Producer side when you use a non default (4) priority the message is routed to a "side topic" named TOPICNAME-jmspriority-PRIORITYLEVEL
- on the Consumer side, we create one Consumer for every possible PRIORITYLEVEL and while we consume we read the data from all the Consumers
- The handling of priority is coded here in the JMS Client, and the algorithm to pick the messages from the Consumer may be hard to implement in a way that does not let consumers starve (in this PR we have only a POC)

The side topics must be pre-created or you need auto-topic-creation to be enabled on the namespace.