### PR TITLE
[feature] ResourceAdapter: allow to start multiple JMS sessions to achieve better parallelism

### DIFF
--- a/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpec.java
+++ b/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpec.java
@@ -37,6 +37,8 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
   private String subscriptionMode = "Shared";
   private String subscriptionName = "";
 
+  private int numSessions = 1;
+
   public String getConfiguration() {
     return configuration;
   }
@@ -92,6 +94,14 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
 
   public void setSubscriptionMode(String subscriptionMode) {
     this.subscriptionMode = subscriptionMode;
+  }
+
+  public int getNumSessions() {
+    return numSessions;
+  }
+
+  public void setNumSessions(int numSessions) {
+    this.numSessions = numSessions;
   }
 
   @Override


### PR DESCRIPTION
Modifications:
In the ResourceAdapter now you can configure the `numSessions` parameter per each "endpoint activation".

Notes:
- The default value is 1
- You cannot start multiple sessions on an Exclusive subscription