### PR TITLE
[improvement] Pool threads used for MessageListeners (jms.sessionListenersThreads)

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -1745,7 +1745,6 @@ public class PulsarConnectionFactory
         });
   }
 
-
   /**
    * Access to the high level Admin JMS API
    *
@@ -1773,7 +1772,7 @@ public class PulsarConnectionFactory
     createConnection().close();
     if (pulsarAdmin == null) {
       throw new IllegalStateException(
-              "This PulsarConnectionFactory is not configured to bootstrap a PulsarAdmin");
+          "This PulsarConnectionFactory is not configured to bootstrap a PulsarAdmin");
     }
     return pulsarAdmin;
   }
@@ -1791,7 +1790,7 @@ public class PulsarConnectionFactory
     public Thread newThread(Runnable r) {
       String name = "jms-session-thread-" + sessionThreadNumber.getAndIncrement();
       Thread thread = new Thread(r, name);
-      thread.setDaemon(false);
+      thread.setDaemon(true);
       thread.setUncaughtExceptionHandler(
           new Thread.UncaughtExceptionHandler() {
             @Override
@@ -1802,5 +1801,4 @@ public class PulsarConnectionFactory
       return thread;
     }
   }
-
 }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -1950,6 +1950,10 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
   }
 
   void scheduleConsumerListenerCycle(PulsarMessageConsumer consumer, boolean immediate) {
+    if (isClosed()) {
+      // session is closed, no need to schedule Listeners
+      return;
+    }
     if (!connection.isStarted()) {
       // try again later
       threadPool.schedule(

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConnectionPausedTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConnectionPausedTest.java
@@ -37,6 +37,7 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -155,11 +156,12 @@ public class ConnectionPausedTest {
             // wait for the consumer to block on "receive"
             beforeReceive.await();
             // wait to enter "receive" method and blocks
-            Thread.sleep(1000);
 
-            log.info("Consumer thread status {}", consumerThread);
-            Stream.of(consumerThread.getStackTrace()).forEach(t -> System.err.println(t));
-            assertEquals(Thread.State.TIMED_WAITING, consumerThread.getState());
+            Awaitility.await().untilAsserted(() -> {
+                      log.info("Consumer thread status {}", consumerThread);
+                      Stream.of(consumerThread.getStackTrace()).forEach(t -> log.info(t.toString()));
+                      assertEquals(Thread.State.TIMED_WAITING, consumerThread.getState());
+                    });
 
             ScheduledExecutorService executeLater = Executors.newSingleThreadScheduledExecutor();
             try {

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/MessageListenerTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/MessageListenerTest.java
@@ -49,8 +49,9 @@ import javax.jms.TextMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Slf4j
 public class MessageListenerTest {
@@ -71,11 +72,14 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void receiveWithListener() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void receiveWithListener(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
+
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
       try (Connection connection = factory.createConnection()) {
         connection.start();
@@ -104,11 +108,13 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void listenerForbiddenMethods() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void listenerForbiddenMethods(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
       try (Connection connection = factory.createConnection()) {
         connection.start();
@@ -174,11 +180,13 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void multipleListenersSameSession() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void multipleListenersSameSession(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
       try (Connection connection = factory.createConnection()) {
         connection.start();
@@ -219,11 +227,13 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void testJMSContextWithListener() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void testJMSContextWithListener(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
       try (JMSContext context = factory.createContext()) {
 
@@ -249,11 +259,13 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void testJMSContextWithListenerBadMethods() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void testJMSContextWithListenerBadMethods(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
 
       try (JMSContext context2 = factory.createContext()) {
@@ -317,11 +329,14 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void testJMSContextAsyncCompletionListenerBadMethods() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void testJMSContextAsyncCompletionListenerBadMethods(int sessionListenersThreads)
+      throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
 
       try (JMSContext context2 = factory.createContext()) {
@@ -392,11 +407,13 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void queueSendRecvMessageListenerTest() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void queueSendRecvMessageListenerTest(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
 
       Queue destination = new PulsarQueue("persistent://public/default/test-" + UUID.randomUUID());
@@ -428,11 +445,13 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void closeConsumerOnMessageListener() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void closeConsumerOnMessageListener(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
 
       Queue destination = new PulsarQueue("persistent://public/default/test-" + UUID.randomUUID());
@@ -471,11 +490,13 @@ public class MessageListenerTest {
     }
   }
 
-  @Test
-  public void messageListenerInternalError() throws Exception {
+  @ParameterizedTest(name = "sessionListenersThreads {0}")
+  @ValueSource(ints = {0, 4})
+  public void messageListenerInternalError(int sessionListenersThreads) throws Exception {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("webServiceUrl", cluster.getAddress());
+    properties.put("jms.sessionListenersThreads", sessionListenersThreads);
     try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
 
       Queue destination = new PulsarQueue("persistent://public/default/test-" + UUID.randomUUID());


### PR DESCRIPTION
Motivation: 
 see #88 and #87 
 
Up to 3.0.0 when you use MessageListeners the JMS starts one thread per Session.
That thread runs all the Consumers with MessageListeners registered on the Session.

Some downsides:
- if you have many Sessions you have too many Threads, and this can be a problem (because a JVM Thread is mapped to a native Linux Thread)
- if you have multiple Consumers on the same Session they cannot execute the MessageListeners concurrently and this limits parallelism


Modifications:
- use a thread pool to run the Consumers

How to enable it ?

Configure `jms.sessionListenersThreads=NUMBER OF THREADS` in the PulsarConnectionFactory configuration.

It is enabled by default