### PR TITLE
Enable hostname verification by default

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -455,7 +455,7 @@ public class PulsarConnectionFactory
 
         boolean tlsEnableHostnameVerification =
             Boolean.parseBoolean(
-                getAndRemoveString("tlsEnableHostnameVerification", "false", configurationCopy));
+                getAndRemoveString("tlsEnableHostnameVerification", "true", configurationCopy));
         final String tlsTrustCertsFilePath =
             (String) getAndRemoveString("tlsTrustCertsFilePath", "", configurationCopy);
 

--- a/tck-executor/conf/client.conf
+++ b/tck-executor/conf/client.conf
@@ -48,7 +48,7 @@ tlsAllowInsecureConnection=false
 
 # Whether server hostname must match the common name of the certificate
 # the server is using.
-tlsEnableHostnameVerification=false
+tlsEnableHostnameVerification=true
 
 # Path for the trusted TLS certificate file.
 # This cert is used to verify that any cert presented by a server


### PR DESCRIPTION
In order to be secure by default, I propose we enable hostname verification by default. This could be a breaking change for users relying on this feature being disabled. We'll need to address that in the release notes or with a major version bump.