### PR TITLE
[feature][jndi] Allow to share resources across multiple contexts (jms.useSharedJNDIContext)

### DIFF
--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConnectionPausedTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ConnectionPausedTest.java
@@ -157,9 +157,12 @@ public class ConnectionPausedTest {
             beforeReceive.await();
             // wait to enter "receive" method and blocks
 
-            Awaitility.await().untilAsserted(() -> {
+            Awaitility.await()
+                .untilAsserted(
+                    () -> {
                       log.info("Consumer thread status {}", consumerThread);
-                      Stream.of(consumerThread.getStackTrace()).forEach(t -> log.info(t.toString()));
+                      Stream.of(consumerThread.getStackTrace())
+                          .forEach(t -> log.info(t.toString()));
                       assertEquals(Thread.State.TIMED_WAITING, consumerThread.getState());
                     });
 

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JNDITest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JNDITest.java
@@ -17,10 +17,13 @@ package com.datastax.oss.pulsar.jms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.datastax.oss.pulsar.jms.jndi.PulsarContext;
 import com.datastax.oss.pulsar.jms.jndi.PulsarInitialContextFactory;
 import com.datastax.oss.pulsar.jms.utils.PulsarCluster;
 import java.nio.file.Path;
@@ -59,7 +62,7 @@ public class JNDITest {
     }
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "autoCloseConnectionFactory {0}")
   @ValueSource(strings = {"true", "false", ""})
   public void basicJDNITest(String autoCloseConnectionFactory) throws Exception {
 
@@ -69,7 +72,8 @@ public class JNDITest {
     properties.setProperty(Context.PROVIDER_URL, cluster.getAddress());
 
     if (!autoCloseConnectionFactory.isEmpty()) {
-      properties.setProperty("autoCloseConnectionFactory", autoCloseConnectionFactory);
+      properties.setProperty(
+          PulsarContext.AUTOCLOSE_CONNECTION_FACTORY, autoCloseConnectionFactory);
     }
 
     Map<String, Object> producerConfig = new HashMap<>();
@@ -134,6 +138,103 @@ public class JNDITest {
       assertFalse(factory != null && factory.isClosed());
     } else {
       fail();
+    }
+  }
+
+  @ParameterizedTest(name = "autoCloseConnectionFactory {0}")
+  @ValueSource(strings = {"true", "false"})
+  public void testSharedContext(String autoCloseConnectionFactory) throws Exception {
+
+    Properties properties = new Properties();
+    properties.setProperty(
+        Context.INITIAL_CONTEXT_FACTORY, PulsarInitialContextFactory.class.getName());
+    properties.setProperty(Context.PROVIDER_URL, cluster.getAddress());
+    properties.setProperty(PulsarContext.USE_SHARED_JNDICONTEXT, "true");
+    properties.setProperty(PulsarContext.AUTOCLOSE_CONNECTION_FACTORY, autoCloseConnectionFactory);
+
+    javax.naming.Context jndiContext1 = new InitialContext(properties);
+    javax.naming.Context jndiContext2 = new InitialContext(properties);
+
+    PulsarConnectionFactory factory1 =
+        (PulsarConnectionFactory) jndiContext1.lookup("ConnectionFactory");
+    PulsarConnectionFactory factory2 =
+        (PulsarConnectionFactory) jndiContext2.lookup("ConnectionFactory");
+    assertSame(factory1, factory2);
+
+    // close context1
+    jndiContext1.close();
+    assertFalse(factory1.isClosed());
+
+    javax.naming.Context jndiContext3 = new InitialContext(properties);
+
+    PulsarConnectionFactory factory3 =
+        (PulsarConnectionFactory) jndiContext3.lookup("ConnectionFactory");
+    assertSame(factory1, factory3);
+
+    jndiContext2.close();
+    assertFalse(factory1.isClosed());
+
+    jndiContext3.close();
+
+    if ("true".equals(autoCloseConnectionFactory)) {
+      // all the references are closed, so the factory should have been closed as well
+      assertTrue(factory1.isClosed());
+    } else {
+      assertFalse(factory1.isClosed());
+      factory1.close();
+    }
+
+    // new context (but same properties), new factory...
+    javax.naming.Context jndiContext4 = new InitialContext(properties);
+    PulsarConnectionFactory factory4 =
+        (PulsarConnectionFactory) jndiContext4.lookup("ConnectionFactory");
+    assertNotSame(factory4, factory3);
+    jndiContext4.close();
+
+    if ("true".equals(autoCloseConnectionFactory)) {
+      // all the references are closed, so the factory should have been closed as well
+      assertTrue(factory4.isClosed());
+    } else {
+      assertFalse(factory4.isClosed());
+      factory4.close();
+    }
+
+    javax.naming.Context jndiContext5 = new InitialContext(properties);
+    javax.naming.Context jndiContext6 = new InitialContext(properties);
+
+    Properties newProperties = new Properties();
+    newProperties.putAll(properties);
+    newProperties.put("enableTransaction", true);
+    // different configuration
+    javax.naming.Context jndiContext7 = new InitialContext(newProperties);
+
+    PulsarConnectionFactory factory5 =
+        (PulsarConnectionFactory) jndiContext5.lookup("ConnectionFactory");
+    PulsarConnectionFactory factory6 =
+        (PulsarConnectionFactory) jndiContext6.lookup("ConnectionFactory");
+    PulsarConnectionFactory factory7 =
+        (PulsarConnectionFactory) jndiContext7.lookup("ConnectionFactory");
+    assertSame(factory5, factory6);
+    assertNotSame(factory5, factory7);
+
+    jndiContext5.close();
+    jndiContext6.close();
+    if ("true".equals(autoCloseConnectionFactory)) {
+      // all the references are closed, so the factory should have been closed as well
+      assertTrue(factory5.isClosed());
+      assertFalse(factory7.isClosed());
+    } else {
+      assertFalse(factory5.isClosed());
+      factory5.close();
+    }
+
+    jndiContext7.close();
+    if ("true".equals(autoCloseConnectionFactory)) {
+      // all the references are closed, so the factory should have been closed as well
+      assertTrue(factory7.isClosed());
+    } else {
+      assertFalse(factory7.isClosed());
+      factory7.close();
     }
   }
 }


### PR DESCRIPTION
Motivation:
In some application servers (like JBoss) the container create one InitialContext per each MessageDriven Bean, and this in turn leads to creating many PulsarConnectionFactory. 
Each PulsarConnectionFactory creates a PulsarClient with a pool of connections to the Pulsar Brokers.
In order to support this use case it is requested to add a mechanism to pool the PulsarContext instances that are internally used by the ephemeral instances of InitialContext. 


Modifications:
- Add a new configuration option for the JNDI InitialContext (`jms.useSharedJNDIContext`)
- With this feature the application will be able to share the same PulsarConnectionFactory across different InitialContext instances
- Add test cases

Compatibility:
This feature is disabled by default and so it is 100% compatible with the previous releases.
The user has to explicitly turn it on by setting jms.useSharedJNDIContext while creating the InitialContext