### PR TITLE
[improvement] Allow concurrent processing with ConnectionConsumer (jms.connectionConsumerParallelism)

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
@@ -15,9 +15,11 @@
  */
 package com.datastax.oss.pulsar.jms;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -32,7 +34,9 @@ import javax.jms.InvalidClientIDException;
 import javax.jms.InvalidDestinationException;
 import javax.jms.InvalidSelectorException;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
 import javax.jms.Queue;
 import javax.jms.QueueConnection;
 import javax.jms.QueueSession;
@@ -45,6 +49,7 @@ import javax.jms.Topic;
 import javax.jms.TopicConnection;
 import javax.jms.TopicSession;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.SubscriptionType;
 
 @Slf4j
 public class PulsarConnection implements Connection, QueueConnection, TopicConnection {
@@ -694,7 +699,9 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
       throws JMSException {
     checkNotClosed();
     return buildConnectionConsumer(
-        sessionPool, (session) -> session.createConsumer(destination, messageSelector));
+        sessionPool,
+        maxMessages,
+        (session) -> session.createConsumer(destination, messageSelector));
   }
 
   /**
@@ -741,6 +748,7 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
     checkNotClosed();
     return buildConnectionConsumer(
         sessionPool,
+        maxMessages,
         session -> session.createSharedConsumer(topic, subscriptionName, messageSelector));
   }
 
@@ -788,6 +796,7 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
     checkNotClosed();
     return buildConnectionConsumer(
         sessionPool,
+        maxMessages,
         session -> session.createDurableConsumer(topic, subscriptionName, messageSelector, false));
   }
 
@@ -835,6 +844,7 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
     checkNotClosed();
     return buildConnectionConsumer(
         sessionPool,
+        maxMessages,
         session -> session.createSharedDurableConsumer(topic, subscriptionName, messageSelector));
   }
 
@@ -938,11 +948,13 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
 
   @Override
   public ConnectionConsumer createConnectionConsumer(
-      Queue queue, String messageSelector, ServerSessionPool serverSessionPool, int i)
+      Queue queue, String messageSelector, ServerSessionPool serverSessionPool, int maxMessages)
       throws JMSException {
     checkNotClosed();
     return buildConnectionConsumer(
-        serverSessionPool, (session) -> session.createConsumer(queue, messageSelector));
+        serverSessionPool,
+        maxMessages,
+        (session) -> session.createConsumer(queue, messageSelector));
   }
 
   @Override
@@ -952,10 +964,12 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
 
   @Override
   public ConnectionConsumer createConnectionConsumer(
-      Topic topic, String messageSelector, ServerSessionPool serverSessionPool, int i)
+      Topic topic, String messageSelector, ServerSessionPool serverSessionPool, int maxMessages)
       throws JMSException {
     return buildConnectionConsumer(
-        serverSessionPool, (session) -> session.createConsumer(topic, messageSelector));
+        serverSessionPool,
+        maxMessages,
+        (session) -> session.createConsumer(topic, messageSelector));
   }
 
   void removeTemporaryDestination(PulsarTemporaryDestination pulsarTemporaryDestination) {
@@ -972,16 +986,91 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
   }
 
   private ConnectionConsumer buildConnectionConsumer(
-      ServerSessionPool sessionPool, ConsumerBuilder consumerBuilder) throws JMSException {
-    ServerSession serverSession = sessionPool.getServerSession();
-    Session session = serverSession.getSession();
-    // this session is supposed to have a MessageListener that receives the messages
-    MessageConsumer consumer = consumerBuilder.build(session);
-    consumer.setMessageListener(session.getMessageListener());
+      ServerSessionPool sessionPool, int maxMessages, ConsumerBuilder consumerBuilder)
+      throws JMSException {
+
+    // create one session
+    PulsarSession dispatcherSession =
+        createSession(
+            false,
+            PulsarJMSConstants.INDIVIDUAL_ACKNOWLEDGE,
+            ConsumerConfiguration.buildConsumerConfiguration(
+                ImmutableMap.of("receiverQueueSize", maxMessages)));
+
+    // create connectionConsumerParallelism consumers
+    PulsarMessageConsumer consumer =
+        (PulsarMessageConsumer) consumerBuilder.build(dispatcherSession);
+    List<PulsarMessageConsumer> consumers = new ArrayList<>();
+    consumers.add(consumer);
+    int connectionConsumerParallelism = factory.getConnectionConsumerParallelism();
+    if (consumer.getSubscriptionType() == SubscriptionType.Shared
+        || consumer.getSubscriptionType() == SubscriptionType.Key_Shared) {
+      while (consumers.size() < connectionConsumerParallelism) {
+        PulsarMessageConsumer additionalConsumer =
+            (PulsarMessageConsumer) consumerBuilder.build(dispatcherSession);
+        consumers.add(additionalConsumer);
+      }
+    }
+
     ConnectionConsumer connectionConsumer =
-        new PulsarConnectionConsumer((PulsarMessageConsumer) consumer, sessionPool);
-    serverSession.start();
+        new PulsarConnectionConsumer(dispatcherSession, consumers, sessionPool);
+    for (PulsarMessageConsumer c : consumers) {
+      c.setMessageListener(new ConsumerBuilderMessageListener(sessionPool));
+    }
     return connectionConsumer;
+  }
+
+  private class ConsumerBuilderMessageListener implements MessageListener {
+    private final ServerSessionPool sessionPool;
+
+    public ConsumerBuilderMessageListener(ServerSessionPool sessionPool) {
+      this.sessionPool = sessionPool;
+    }
+
+    @Override
+    public void onMessage(Message message) {
+      try {
+        PulsarMessage pulsarMessage = (PulsarMessage) message;
+        // this method may be "blocking" if the pool is exhausted
+        ServerSession serverSession = sessionPool.getServerSession();
+        // this session must have been created by this connection
+        // it is a dummy session that is only a Holder for the MessageListener
+        // that actually execute the MessageDriven bean code
+        PulsarSession wrappedByServerSideSession = (PulsarSession) serverSession.getSession();
+        if (wrappedByServerSideSession.getConnection() != PulsarConnection.this) {
+          log.error(
+              "Session {} has not been created by this connection {}",
+              wrappedByServerSideSession,
+              this);
+          return;
+        }
+        CompletableFuture<Void> handle = new CompletableFuture<>();
+        final MessageListener messageListener = wrappedByServerSideSession.getMessageListener();
+        wrappedByServerSideSession.setupConnectionConsumerTask(
+            () -> {
+              // this will be executed on another thread managed by the JavaEE container
+              // the thread will handle transactions demarcations.
+              try {
+                messageListener.onMessage(pulsarMessage);
+                handle.complete(null);
+              } catch (Exception err) {
+                log.error("Error while processing message {}", pulsarMessage, err);
+                handle.completeExceptionally(err);
+              }
+            });
+        // serverSession.start() starts a new "Work" (using WorkManager) to
+        // execute the Session.run() method of the dummy session wrapped by
+        // the ServerSession, that happens on a separate thread
+        serverSession.start();
+        // also the ServerSession will not be assigned to another work
+        // until the processing of this message has completed
+
+        handle.get();
+      } catch (Exception err) {
+        // notify the listener
+        throw new RuntimeException(err);
+      }
+    }
   }
 
   void refreshServerSideSelectors() {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -156,6 +156,8 @@ public class PulsarConnectionFactory
 
   private transient int sessionListenersThreads;
 
+  private transient int connectionConsumerParallelism = 1;
+
   public PulsarConnectionFactory() throws JMSException {
     this(new HashMap<>());
   }
@@ -330,6 +332,10 @@ public class PulsarConnectionFactory
                   "jms.sessionListenersThreads",
                   (Runtime.getRuntime().availableProcessors() * 2) + "",
                   configurationCopy));
+
+      this.connectionConsumerParallelism =
+          Integer.parseInt(
+              getAndRemoveString("jms.connectionConsumerParallelism", "1", configurationCopy));
 
       final String rawTopicSharedSubscriptionType =
           getAndRemoveString(
@@ -1767,6 +1773,10 @@ public class PulsarConnectionFactory
           "This PulsarConnectionFactory is not configured to bootstrap a PulsarAdmin");
     }
     return pulsarAdmin;
+  }
+
+  public synchronized int getConnectionConsumerParallelism() {
+    return connectionConsumerParallelism;
   }
 
   public synchronized ScheduledExecutorService getSessionListenersThreadPool() {

--- a/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarMessageEndpoint.java
+++ b/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarMessageEndpoint.java
@@ -266,13 +266,9 @@ public class PulsarMessageEndpoint implements MessageListener {
 
     @Override
     public void rollback(Xid xid) throws XAException {
-      try {
-        message.negativeAck();
-        if (log.isDebugEnabled()) {
-          log.debug("rollback {} ack message {}", xid, message);
-        }
-      } catch (JMSException err) {
-        throw new XAException(err + "");
+      message.negativeAck();
+      if (log.isDebugEnabled()) {
+        log.debug("rollback {} ack message {}", xid, message);
       }
     }
 


### PR DESCRIPTION
Motivation:
- currently when a JavaEE container uses the ConnectionConsumer API the JMS client processes only one message at a time, this is because basically it creates only one "MessageConsumer"

Modifications:
- add a new ConnectionFactory parameter jms.connectionConsumerParallelism (default is 1, so the behaviour is the same as before)
- update the way the ConnectionConsumer interacts with the ServerSessionPool
- update PulsarSession.run() implementation in order to match the the protocol required by ServerSessionPool (and in particular the JBoss 5 implementation)
- add test cases

Notes:
-. The parameter` jms.connectionConsumerParallelism` should be configured taking into account the number of MessageDriverBeans and the value of `jms.sessionListenersThreads` and the number of Sessions created by the container per each MDB (in JBoss this is minSession/maxSession).
The default value, 1, is pretty conservative and it means that for each ConnectionConsumer the application is going to process only one message at a time.
- In case of a Exclusive (or Failover) subscription type used by the MessageConsumer, the parallelism is set automatically to 1 because it is not possible to start multiple consumers on the same Exclusive subscription (and starting more than 1 in a Failover subscription brings no benefit)
