### PR TITLE
[improvement] ConnectionConsumer - prevent blocking on getServerSession()

### DIFF
--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -118,8 +118,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionConsumer.java
@@ -16,29 +16,52 @@
 package com.datastax.oss.pulsar.jms;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.jms.ConnectionConsumer;
 import javax.jms.IllegalStateException;
 import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.ServerSession;
 import javax.jms.ServerSessionPool;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 class PulsarConnectionConsumer implements ConnectionConsumer {
-  private final List<PulsarMessageConsumer> consumers;
+
+  private static final long TIMEOUT_RECEIVE = 10L;
+
+  private final PulsarMessageConsumer consumer;
   private final PulsarSession dispatcherSession;
   private final ServerSessionPool serverSessionPool;
-  private volatile boolean closed;
+  private final AtomicBoolean closed = new AtomicBoolean();
+  private final Thread spool;
+  private final int maxMessages;
 
   PulsarConnectionConsumer(
       PulsarSession dispatcherSession,
-      List<PulsarMessageConsumer> consumers,
-      ServerSessionPool serverSessionPool) {
+      PulsarMessageConsumer consumer,
+      ServerSessionPool serverSessionPool,
+      int maxMessages) {
     this.dispatcherSession = dispatcherSession;
-    this.consumers = consumers;
+    this.consumer = consumer;
     this.serverSessionPool = serverSessionPool;
+    this.maxMessages = maxMessages;
+
+    // unfortunately due to the blocking nature of ServerSessionPool.getServerSession()
+    // we must
+    this.spool = new Thread(new Spool());
+    this.spool.setDaemon(true);
+    this.spool.setName(
+        "jms-connection-consumer-" + serverSessionPool + "-" + consumer.getDestination().getName());
+  }
+
+  public void start() {
+    spool.start();
   }
 
   @Override
   public ServerSessionPool getServerSessionPool() throws JMSException {
-    if (closed) {
+    if (closed.get()) {
       throw new IllegalStateException("The Connection Consumer is closed");
     }
     return serverSessionPool;
@@ -46,14 +69,63 @@ class PulsarConnectionConsumer implements ConnectionConsumer {
 
   @Override
   public void close() throws JMSException {
-    closed = true;
-    for (PulsarMessageConsumer consumer : consumers) {
-      try {
-        consumer.close();
-      } catch (JMSException ignore) {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    try {
+      this.spool.join();
+    } catch (InterruptedException err) {
+      Utils.handleException(err);
+    }
+    this.consumer.close();
+    this.dispatcherSession.close();
+  }
 
+  private class Spool implements Runnable {
+
+    @Override
+    public void run() {
+      while (!closed.get()) {
+        try {
+          // this method may be "blocking" if the pool is exhausted
+          ServerSession serverSession;
+          try {
+            serverSession = serverSessionPool.getServerSession();
+          } catch (JMSException internalContainerError) {
+            log.error("Container error", internalContainerError);
+            break;
+          }
+          // pick a message after getting the ServerSession
+          // otherwise the ackTimeout will make the message be negatively acknowledged
+          // while waiting for the ServerSession to be available
+          List<Message> messages = consumer.batchReceive(maxMessages, TIMEOUT_RECEIVE);
+          if (!messages.isEmpty()) {
+            // this session must have been created by this connection
+            // it is a dummy session that is only a Holder for the MessageListener
+            // that actually execute the MessageDriven bean code
+            PulsarSession wrappedByServerSideSession = (PulsarSession) serverSession.getSession();
+
+            wrappedByServerSideSession.setupConnectionConsumerTask(messages);
+
+            // serverSession.start() starts a new "Work" (using WorkManager) to
+            // execute the Session.run() method of the dummy session wrapped by
+            // the ServerSession, that happens on a separate thread
+            serverSession.start();
+          } else {
+            // retun the session to the pool
+            serverSession.start();
+          }
+        } catch (JMSException error) {
+          log.error("internal error", error);
+
+          // back-off
+          try {
+            Thread.sleep(1000);
+          } catch (InterruptedException stopThread) {
+            break;
+          }
+        }
       }
     }
-    dispatcherSession.close();
   }
 }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageConsumer.java
@@ -295,7 +295,6 @@ public class PulsarMessageConsumer implements MessageConsumer, TopicSubscriber, 
     if (maxMessages < 0) {
       maxMessages = 1;
     }
-    long start = System.currentTimeMillis();
 
     // block until we receive a message or timeout expires
     Message message = receive(timeoutMs);

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleMessageListener.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleMessageListener.java
@@ -15,12 +15,12 @@
  */
 package com.datastax.oss.pulsar.jms;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.jms.Message;
 import javax.jms.MessageListener;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 public class SimpleMessageListener implements MessageListener {
   final List<Message> receivedMessages = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
### Motivation

ServerSessionPool.getServerSession() may block (see paragraph 11.2.3 in the JMS 2.0 specs) and this is a problem while using the shared pool of threads that backs the execution of MessageListeners

### Modifications

Start a dedicated thread per each ConnectionConsumer. The thread blocks until it gets a ServerSession and then it tries to receive up to `maxMessages` from the Pulsar MessageConsumer 