### PR TITLE
[feature] ConnectionConsumer - force MDB parallelism by maxMessages (jms.maxMessagesLimitsParallelism) and other performance improvements

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
@@ -158,7 +158,7 @@ final class PulsarQueueBrowser implements QueueBrowser {
               } else {
                 nextMessage =
                     PulsarMessage.decode(
-                        null, reader.readNext(BROWSER_READ_TIMEOUT, TimeUnit.MILLISECONDS));
+                        null, null, reader.readNext(BROWSER_READ_TIMEOUT, TimeUnit.MILLISECONDS));
                 if (nextMessage == null) {
                   finished = true;
                   return;

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleMessageListener.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleMessageListener.java
@@ -28,6 +28,6 @@ public class SimpleMessageListener implements MessageListener {
   @Override
   public void onMessage(Message message) {
     receivedMessages.add(message);
-    log.info("{} - received {}, total {}", this, message, receivedMessages.size());
+    // log.info("{} - received {}, total {}", this, message, receivedMessages.size());
   }
 }

--- a/pulsar-jms/src/test/resources/log4j2.xml
+++ b/pulsar-jms/src/test/resources/log4j2.xml
@@ -27,8 +27,8 @@
       <AppenderRef ref="Console"/>
     </Root>
     <logger name="org.apache.bookkeeper" level="error" additivity="true"/>
-    <logger name="org.apache.bookkeeper.mledger" level="info" additivity="true"/>
-    <logger name="org.apache.pulsar" level="info" additivity="true"/>
+    <logger name="org.apache.bookkeeper.mledger" level="error" additivity="true"/>
+    <logger name="org.apache.pulsar" level="warn" additivity="true"/>
     <logger name="org.apache.zookeeper" level="error" additivity="true"/>
     <logger name="org.apache.curator" level="error" additivity="true"/>
     <logger name="org.eclipse.jetty" level="error" additivity="true"/>


### PR DESCRIPTION
### Motivation
ActiveMQ + JBoss users are used to see that maxMessages configuration in MessageDriven beans correspond to the maximum parallelism of the MDB. This is basically due to the fact that ActiveMQConnection uses "maxMessages" hint in order to configure the prefetchSize on the internal Consumer.

In order to help ActiveMQ + JBoss users to migrate to Pulsar we need to implement a flag jms.maxMessagesLimitsParallelism to enforce this behaviour

### Modifications
- implement jms.maxMessagesLimitsParallelism
- refactor some MessageConsumer and PulsarSession mechanism in order to reduce lock contention
- do not start the listeners threadpool is not needed