### PR TITLE
[feature] ResourceAdapter: allow to override consumerConfig from the MessageDrivenBean activation properties

### DIFF
--- a/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpec.java
+++ b/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpec.java
@@ -18,12 +18,21 @@ package com.datastax.oss.pulsar.jms.rar;
 import com.datastax.oss.pulsar.jms.PulsarDestination;
 import com.datastax.oss.pulsar.jms.PulsarQueue;
 import com.datastax.oss.pulsar.jms.PulsarTopic;
+
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+import javax.jms.IllegalStateRuntimeException;
 import javax.resource.ResourceException;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.InvalidPropertyException;
 import javax.resource.spi.ResourceAdapter;
 import javax.resource.spi.ResourceAdapterAssociation;
+
+import com.datastax.oss.pulsar.jms.Utils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -32,7 +41,17 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
   private ResourceAdapter resourceAdapter;
   private String destination;
   private String destinationType = "queue";
+  /**
+   * Configuration for the underlying PulsarConnectionFactory.
+   * Factories are cached, using this configuration as key.
+   */
   private String configuration = "{}";
+  /**
+   * Override the consumer configuration.
+   * This allows you to have different consumerConfig but
+   * still share the PulsarConnectionFactory
+   */
+  private String consumerConfig = "{}";
   private String subscriptionType = "Durable";
   private String subscriptionMode = "Shared";
   private String subscriptionName = "";
@@ -46,14 +65,6 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
   public void setConfiguration(String configuration) {
     log.info("setConfiguration {}", configuration);
     this.configuration = configuration;
-  }
-
-  public PulsarDestination getPulsarDestination() {
-    if (destinationType == null || destinationType.toLowerCase().contains("queue")) {
-      return new PulsarQueue(destination);
-    } else {
-      return new PulsarTopic(destination);
-    }
   }
 
   public String getDestination() {
@@ -230,4 +241,33 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
       return this.configuration;
     }
   }
+
+  public String getConsumerConfig() {
+    return consumerConfig;
+  }
+
+  public void setConsumerConfig(String consumerConfig) {
+    log.info("setConsumerConfig {}", consumerConfig);
+    this.consumerConfig = consumerConfig;
+  }
+
+  Map<String, Object> buildConsumerConfiguration() {
+    String overrideConsumerConfiguration = consumerConfig;
+    if (overrideConsumerConfiguration != null) {
+      overrideConsumerConfiguration = overrideConsumerConfiguration.trim();
+    } else {
+      return Collections.emptyMap();
+    }
+    Map<String, Object> result = null;
+    if (!overrideConsumerConfiguration.isEmpty() && !overrideConsumerConfiguration.equals("{}")) {
+      String jsonConfig = overrideConsumerConfiguration;
+      result = (Map<String, Object>) Utils.runtimeException(() -> new ObjectMapper().readValue(jsonConfig, Map.class));
+    }
+    if (result == null) {
+      return Collections.emptyMap();
+    } else {
+      return result;
+    }
+  }
+
 }

--- a/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpec.java
+++ b/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpec.java
@@ -15,24 +15,16 @@
  */
 package com.datastax.oss.pulsar.jms.rar;
 
-import com.datastax.oss.pulsar.jms.PulsarDestination;
-import com.datastax.oss.pulsar.jms.PulsarQueue;
-import com.datastax.oss.pulsar.jms.PulsarTopic;
-
+import com.datastax.oss.pulsar.jms.Utils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import javax.jms.IllegalStateRuntimeException;
 import javax.resource.ResourceException;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.InvalidPropertyException;
 import javax.resource.spi.ResourceAdapter;
 import javax.resource.spi.ResourceAdapterAssociation;
-
-import com.datastax.oss.pulsar.jms.Utils;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -42,16 +34,16 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
   private String destination;
   private String destinationType = "queue";
   /**
-   * Configuration for the underlying PulsarConnectionFactory.
-   * Factories are cached, using this configuration as key.
+   * Configuration for the underlying PulsarConnectionFactory. Factories are cached, using this
+   * configuration as key.
    */
   private String configuration = "{}";
   /**
-   * Override the consumer configuration.
-   * This allows you to have different consumerConfig but
-   * still share the PulsarConnectionFactory
+   * Override the consumer configuration. This allows you to have different consumerConfig but still
+   * share the PulsarConnectionFactory
    */
   private String consumerConfig = "{}";
+
   private String subscriptionType = "Durable";
   private String subscriptionMode = "Shared";
   private String subscriptionName = "";
@@ -261,7 +253,9 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
     Map<String, Object> result = null;
     if (!overrideConsumerConfiguration.isEmpty() && !overrideConsumerConfiguration.equals("{}")) {
       String jsonConfig = overrideConsumerConfiguration;
-      result = (Map<String, Object>) Utils.runtimeException(() -> new ObjectMapper().readValue(jsonConfig, Map.class));
+      result =
+          (Map<String, Object>)
+              Utils.runtimeException(() -> new ObjectMapper().readValue(jsonConfig, Map.class));
     }
     if (result == null) {
       return Collections.emptyMap();
@@ -269,5 +263,4 @@ public class PulsarActivationSpec implements ActivationSpec, ResourceAdapterAsso
       return result;
     }
   }
-
 }

--- a/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarMessageEndpoint.java
+++ b/resource-adapter/src/main/java/com/datastax/oss/pulsar/jms/rar/PulsarMessageEndpoint.java
@@ -21,6 +21,7 @@ import com.datastax.oss.pulsar.jms.PulsarJMSContext;
 import com.datastax.oss.pulsar.jms.PulsarMessage;
 import com.datastax.oss.pulsar.jms.PulsarQueue;
 import com.datastax.oss.pulsar.jms.PulsarTopic;
+import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -41,10 +42,6 @@ import javax.resource.spi.endpoint.MessageEndpointFactory;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
-
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -74,8 +71,6 @@ public class PulsarMessageEndpoint implements MessageListener {
     this.activationSpec = activationSpec;
     this.sessions = new ArrayList<>();
   }
-
-
 
   public MessageEndpointFactory getMessageEndpointFactory() {
     return messageEndpointFactory;
@@ -112,14 +107,20 @@ public class PulsarMessageEndpoint implements MessageListener {
   }
 
   void startSession() {
-    PulsarJMSContext context = (PulsarJMSContext) pulsarConnectionFactory.createContext(JMSContext.CLIENT_ACKNOWLEDGE);
+    PulsarJMSContext context =
+        (PulsarJMSContext) pulsarConnectionFactory.createContext(JMSContext.CLIENT_ACKNOWLEDGE);
     Map<String, Object> customConfiguration = activationSpec.buildConsumerConfiguration();
     PulsarDestination pulsarDestination =
-            getPulsarDestination(activationSpec.getDestinationType(), activationSpec.getDestination());
+        getPulsarDestination(activationSpec.getDestinationType(), activationSpec.getDestination());
     if (!customConfiguration.isEmpty()) {
-      log.info("Endpoint for {} overrides consumerConfig with {}", pulsarDestination, customConfiguration);
-      context = (PulsarJMSContext) context.createContext(context.getSessionMode(),
-              ImmutableMap.of("consumerConfig", customConfiguration));
+      log.info(
+          "Endpoint for {} overrides consumerConfig with {}",
+          pulsarDestination,
+          customConfiguration);
+      context =
+          (PulsarJMSContext)
+              context.createContext(
+                  context.getSessionMode(), ImmutableMap.of("consumerConfig", customConfiguration));
     }
     sessions.add(context);
     if (pulsarDestination.isQueue()) {

--- a/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpecTest.java
+++ b/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpecTest.java
@@ -19,11 +19,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import javax.resource.spi.InvalidPropertyException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 @Slf4j
 public class PulsarActivationSpecTest {

--- a/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpecTest.java
+++ b/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/PulsarActivationSpecTest.java
@@ -17,10 +17,13 @@ package com.datastax.oss.pulsar.jms.rar;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.resource.spi.InvalidPropertyException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 @Slf4j
 public class PulsarActivationSpecTest {
@@ -146,5 +149,27 @@ public class PulsarActivationSpecTest {
     spec.setConfiguration("{   }");
     assertEquals("bar", spec.getMergedConfiguration("bar"));
     assertEquals("{   }", spec.getConfiguration());
+  }
+
+  @Test
+  public void testConsumerConfiguration() throws Exception {
+    PulsarActivationSpec spec = new PulsarActivationSpec();
+    String configuration = "{\"deadLetterPolicy\":{\"deadLetterTopic\":\"dlq-topic\"}}";
+    spec.setConsumerConfig(configuration);
+    Map<String, Object> parsed = spec.buildConsumerConfiguration();
+    Map<String, Object> deadLetterPolicy = (Map<String, Object>) parsed.get("deadLetterPolicy");
+    assertEquals("dlq-topic", deadLetterPolicy.get("deadLetterTopic"));
+
+    spec.setConsumerConfig(null);
+    assertTrue(spec.buildConsumerConfiguration().isEmpty());
+
+    spec.setConsumerConfig("");
+    assertTrue(spec.buildConsumerConfiguration().isEmpty());
+
+    spec.setConsumerConfig("{}");
+    assertTrue(spec.buildConsumerConfiguration().isEmpty());
+
+    spec.setConsumerConfig("   {  }   ");
+    assertTrue(spec.buildConsumerConfiguration().isEmpty());
   }
 }

--- a/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/PulsarMessageEndpointTest.java
+++ b/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/PulsarMessageEndpointTest.java
@@ -367,21 +367,21 @@ public class PulsarMessageEndpointTest {
           verify(context, times(1)).createSharedConsumer(any(), eq("subname"));
         });
 
-
     testCreateConsumer(
-            "topic",
-            "NonDurable",
-            "Shared",
-            1,
-            "{\"deadLetterPolicy\":{\"deadLetterTopic\":\"dlq-topic\"}}",
-            context -> {
-              ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
-              verify(context, times(1))
-                      .createContext(anyInt(), captor.capture());
-              Map<String, Object> consumerConfig = (Map<String, Object>) captor.getValue().get("consumerConfig");
-              Map<String, Object> deadLetterPolicy = (Map<String, Object>) consumerConfig.get("deadLetterPolicy");
-              assertEquals("dlq-topic",  deadLetterPolicy.get("deadLetterTopic"));
-            });
+        "topic",
+        "NonDurable",
+        "Shared",
+        1,
+        "{\"deadLetterPolicy\":{\"deadLetterTopic\":\"dlq-topic\"}}",
+        context -> {
+          ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+          verify(context, times(1)).createContext(anyInt(), captor.capture());
+          Map<String, Object> consumerConfig =
+              (Map<String, Object>) captor.getValue().get("consumerConfig");
+          Map<String, Object> deadLetterPolicy =
+              (Map<String, Object>) consumerConfig.get("deadLetterPolicy");
+          assertEquals("dlq-topic", deadLetterPolicy.get("deadLetterTopic"));
+        });
   }
 
   @Test
@@ -402,7 +402,7 @@ public class PulsarMessageEndpointTest {
         "Shared",
         5,
         null,
-         context -> {
+        context -> {
           verify(context, times(5)).createConsumer(any());
         });
 
@@ -455,7 +455,8 @@ public class PulsarMessageEndpointTest {
     MessageEndpointFactory messageEndpointFactory = mock(MessageEndpointFactory.class);
     PulsarJMSContext context = mock(PulsarJMSContext.class);
 
-    // this is a subcontext used to verify that we can create a new context with an overridden consumerConfig
+    // this is a subcontext used to verify that we can create a new context with an overridden
+    // consumerConfig
     PulsarJMSContext subContext = mock(PulsarJMSContext.class);
     when(pulsarConnectionFactory.createContext(eq(JMSContext.CLIENT_ACKNOWLEDGE)))
         .thenReturn(context);
@@ -466,7 +467,8 @@ public class PulsarMessageEndpointTest {
     when(context.createSharedDurableConsumer(any(Topic.class), any()))
         .thenReturn(mock(JMSConsumer.class));
     when(context.createSharedConsumer(any(Topic.class), any())).thenReturn(mock(JMSConsumer.class));
-    when(subContext.createSharedConsumer(any(Topic.class), any())).thenReturn(mock(JMSConsumer.class));
+    when(subContext.createSharedConsumer(any(Topic.class), any()))
+        .thenReturn(mock(JMSConsumer.class));
 
     PulsarActivationSpec activationSpec = new PulsarActivationSpec();
     activationSpec.setDestination("MyDest");

--- a/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/ResourceAdapterTest.java
+++ b/resource-adapter/src/test/java/com/datastax/oss/pulsar/jms/rar/ResourceAdapterTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.pulsar.jms.PulsarConnectionFactory;
+import com.datastax.oss.pulsar.jms.PulsarJMSContext;
 import javax.jms.Destination;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
@@ -82,7 +83,7 @@ public class ResourceAdapterTest {
           @Override
           protected PulsarConnectionFactory buildConnectionFactory(String config) {
             PulsarConnectionFactory res = mock(PulsarConnectionFactory.class);
-            JMSContext context = mock(JMSContext.class);
+            JMSContext context = mock(PulsarJMSContext.class);
             when(context.createConsumer(any(Destination.class)))
                 .thenReturn(mock(JMSConsumer.class));
             when(res.createContext(anyInt())).thenReturn(context);


### PR DESCRIPTION
Motivation

Currently you can set the consumerConfig in the "configuration" property for Message Driver Beans (PulsarActivactionSpec).
But if you set it in the configuration the Adapter cannot share the configuration with other instances (and so you would have multiple PulsarClient instances and so more connections to the brokers)

Modification

Allow to specific the "consumerConfig", using JSON notation as a Activation Property for MessageDriven beans