### PR TITLE
[improvement] Do not block fovever while closing ConnectionConsumer (jms.connectionConsumerStopTimeout)

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -151,6 +151,8 @@ public class PulsarConnectionFactory
   private transient int refreshServerSideFiltersPeriod = 300;
   private transient boolean maxMessagesLimitsParallelism = false;
 
+  private transient int connectionConsumerStopTimeout = 20000;
+
   private transient Map<String, Object> configuration = Collections.emptyMap();
 
   private transient ScheduledExecutorService sessionListenersThreadPool;
@@ -340,6 +342,10 @@ public class PulsarConnectionFactory
       this.maxMessagesLimitsParallelism =
           Boolean.parseBoolean(
               getAndRemoveString("jms.maxMessagesLimitsParallelism", "false", configurationCopy));
+
+      this.connectionConsumerStopTimeout =
+          Integer.parseInt(
+              getAndRemoveString("jms.connectionConsumerStopTimeout", "20000", configurationCopy));
 
       this.sessionListenersThreads =
           Integer.parseInt(
@@ -1814,6 +1820,10 @@ public class PulsarConnectionFactory
 
   public synchronized boolean isMaxMessagesLimitsParallelism() {
     return maxMessagesLimitsParallelism;
+  }
+
+  public synchronized int getConnectionConsumerStopTimeout() {
+    return connectionConsumerStopTimeout;
   }
 
   private static class SessionListenersThreadFactory implements ThreadFactory {


### PR DESCRIPTION
### Motivation
- during JBoss shutdown the container sequentially closes all the ConnectionConsumer instances
- if there some problem (something hangs) the container doesn't stop propertly


Sample stacktrace from a real stuck JBoss

```
DRM Async Merger#1" #17778 prio=5 os_prio=0 tid=0x00007f7bec183800 nid=0x4649 in Object.wait() [0x00007f7afb1e5000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Thread.join(Thread.java:1252)
	- locked <0x00000003083fa708> (a java.lang.Thread)
	at java.lang.Thread.join(Thread.java:1326)
	at com.datastax.oss.pulsar.jms.PulsarConnectionConsumer.close(PulsarConnectionConsumer.java:101)
	at org.jboss.ejb.plugins.jms.JMSContainerInvoker.innerStopDelivery(JMSContainerInvoker.java:1069)
	at org.jboss.ejb.plugins.jms.JMSContainerInvoker.stopService(JMSContainerInvoker.java:1015)
	at org.jboss.system.ServiceMBeanSupport.jbossInternalStop(ServiceMBeanSupport.java:315)
	at org.jboss.system.ServiceMBeanSupport.jbossInternalLifecycle(ServiceMBeanSupport.java:247)
	at sun.reflect.GeneratedMethodAccessor18.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)
	at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)
	at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)
	at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)
	at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)
	at org.jboss.system.ServiceController$ServiceProxy.invoke(ServiceController.java:978)
	at com.sun.proxy.$Proxy25.stop(Unknown Source)
	at org.jboss.system.ServiceController.stop(ServiceController.java:508)
	at sun.reflect.GeneratedMethodAccessor341.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)
	at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)
	at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)
	at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)
	at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)
	at org.jboss.system.ServiceMBeanSupport.stop(ServiceMBeanSupport.java:204)
	at org.jboss.ejb.MessageDrivenContainer.stopService(MessageDrivenContainer.java:301)

```

### Modifications
- add a new configuration option `jms.connectionConsumerStopTimeout` that controls a maximum time to wait for the internal Spool thread to stop
- the value is in milliseconds, the default value is 20 seconds (20000 ms)
- turn it to zero in order to disable the feature
- add testcases that cover the case, for both the stuck Spool thread and also for the case in which the MessageDriverBean onMessage handler is stuck