### PR TITLE
Upgrade Pulsar Client to 3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn -B package -DskipTests

--- a/.github/workflows/tck-client-side-filters.yaml
+++ b/.github/workflows/tck-client-side-filters.yaml
@@ -16,10 +16,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 8 for TCK Executor
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: 8
+          distribution: 'temurin'
+      - name: Save JDK8 path
+        run: |
+          export JDK8_PATH=$JAVA_HOME
+          echo "JDK8_PATH=$JDK8_PATH" >> $GITHUB_ENV
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Cache local Maven repository
@@ -30,8 +39,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build
+      - name: Build with JDK17
         run: mvn -B clean install -DskipTests -Dspotbugs.skip=true
 
       - name: TCK tests - client side filters
-        run: mvn -B verify -DskipTests -Prun-tck
+        run: JAVA_HOME=$JDK8_PATH mvn -B verify -DskipTests -Prun-tck

--- a/.github/workflows/tck-server-side-filters.yaml
+++ b/.github/workflows/tck-server-side-filters.yaml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -16,10 +16,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 8 for TCK Executor
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: 8
+          distribution: 'temurin'
+      - name: Save JDK8 path
+        run: |
+          export JDK8_PATH=$JAVA_HOME
+          echo "JDK8_PATH=$JDK8_PATH" >> $GITHUB_ENV
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Cache local Maven repository
@@ -30,8 +39,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build
+      - name: Build with JDK17
         run: mvn -B clean install -DskipTests -Dspotbugs.skip=true
 
       - name: TCK tests - server side filters
-        run: mvn -B verify -DskipTests -Prun-tck-server-side-filters
+        run: JAVA_HOME=$JDK8_PATH mvn -B verify -DskipTests -Prun-tck-server-side-filters

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Cache local Maven repository

--- a/activemq-filters/src/main/java/org/apache/activemq/filter/package.html
+++ b/activemq-filters/src/main/java/org/apache/activemq/filter/package.html
@@ -20,7 +20,7 @@
 <body>
 
 <p>
-	Filter implementations for wildcards & JMS selectors
+	Filter implementations for wildcards &amp; JMS selectors
 </p>
 
 </body>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <jms.version>2.0.3</jms.version>
     <!-- waiting for a Apache Pulsar 2.11.0 release, in the meantime we use DataStax Luna Streaming
          that is a fork of Apache Pulsar  -->
-    <pulsar.groupId>com.datastax.oss</pulsar.groupId>
-    <pulsar.version>2.10.3.1</pulsar.version>
+    <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
+    <pulsar.version>3.0.0</pulsar.version>
     <activemq.version>5.16.1</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
@@ -70,6 +70,16 @@
     <commons-compress.version>1.21</commons-compress.version>
     <awaitility.version>4.0.3</awaitility.version>
     <snakeyaml.version>1.31</snakeyaml.version>
+    <!-- required for running tests on JDK11+ -->
+    <test.additional.args>--add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED
+      <!--Mockito-->--add-opens java.base/java.io=ALL-UNNAMED
+      <!--Bookkeeper NativeIO-->--add-opens java.base/java.util=ALL-UNNAMED
+      <!--System Lambda-->--add-opens java.base/sun.net=ALL-UNNAMED
+      <!--netty.DnsResolverUtil-->--add-opens java.management/sun.management=ALL-UNNAMED
+      <!--JvmDefaultGCMetricsLogger & MBeanStatsGenerator-->--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+      <!--MBeanStatsGenerator-->--add-opens java.base/jdk.internal.platform=ALL-UNNAMED
+      <!--LinuxInfoUtils-->
+    </test.additional.args>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -306,26 +316,6 @@ limitations under the License.]]></inlineHeader>
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.22</version>
-          <executions>
-            <execution>
-              <id>check-jdk8</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <configuration>
-                <signature>
-                  <groupId>org.codehaus.mojo.signature</groupId>
-                  <artifactId>java18</artifactId>
-                  <version>1.0</version>
-                </signature>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>au.com.acegi</groupId>
           <artifactId>xml-format-maven-plugin</artifactId>
           <version>3.1.1</version>
@@ -346,6 +336,7 @@ limitations under the License.]]></inlineHeader>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire.version}</version>
           <configuration>
+            <argLine>${test.additional.args}</argLine>
             <trimStackTrace>false</trimStackTrace>
             <systemPropertyVariables>
               <logback.configurationFile>${project.basedir}/src/test/resources/logback-test.xml</logback.configurationFile>

--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -97,8 +97,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
+++ b/pulsar-jms-integration-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/DockerTest.java
@@ -46,6 +46,7 @@ public class DockerTest {
 
   private static final String TEST_PULSAR_DOCKER_IMAGE_NAME =
       System.getProperty("testPulsarDockerImageName");
+  public static final String LUNASTREAMING = "datastax/lunastreaming:2.10_4.4";
 
   @TempDir Path tempDir;
 
@@ -61,13 +62,13 @@ public class DockerTest {
 
   @Test
   public void testPulsar210() throws Exception {
-    test("apachepulsar/pulsar:2.10.0", false);
+    test("apachepulsar/pulsar:2.10.4", false);
   }
 
   @Test
   public void testLunaStreaming210() throws Exception {
     // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.x
-    test("datastax/lunastreaming:2.10_1.6", false);
+    test(LUNASTREAMING, false);
   }
 
   @Test
@@ -77,19 +78,28 @@ public class DockerTest {
 
   @Test
   public void testPulsar210Transactions() throws Exception {
-    test("apachepulsar/pulsar:2.10.0", true);
+    test("apachepulsar/pulsar:2.10.4", true);
+  }
+
+  @Test
+  public void testPulsar211Transactions() throws Exception {
+    test("apachepulsar/pulsar:2.11.1", true);
+  }
+
+  @Test
+  public void testPulsar3Transactions() throws Exception {
+    test("apachepulsar/pulsar:3.0.0", true);
   }
 
   @Test
   public void testLunaStreaming210Transactions() throws Exception {
     // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.x
-    test("datastax/lunastreaming:2.10_1.6", true);
+    test(LUNASTREAMING, true);
   }
 
   @Test
   public void testLunaStreaming210ServerSideSelectors() throws Exception {
-    // waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.6
-    test("datastax/lunastreaming:2.10_1.6", false, true);
+    test(LUNASTREAMING, false, true);
   }
 
   @Test

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -118,8 +118,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
@@ -534,8 +534,8 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
    * <p>This method must not be used in a Java EE web or EJB application. Doing so may cause a
    * {@code JMSException} to be thrown though this is not guaranteed.
    *
-   * @throws IllegalStateException this method has been called by a <tt>MessageListener</tt> on its
-   *     own <tt>Connection</tt>
+   * @throws IllegalStateException this method has been called by a <code>MessageListener</code> on
+   *     its own <code>Connection</code>
    * @throws JMSException if the JMS provider fails to stop message delivery for one of the
    *     following reasons:
    *     <ul>
@@ -599,8 +599,8 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
    * they return control to the JMS provider.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>Connection</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
-   * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
+   * <code>Connection</code> have been completed and any <code>CompletionListener</code> callbacks
+   * have returned. Incomplete sends should be allowed to complete normally unless an error occurs.
    *
    * <p>For the avoidance of doubt, if an exception listener for this connection is running when
    * {@code close} is invoked, there is no requirement for the {@code close} call to wait until the
@@ -612,8 +612,9 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
    * session's work is determined later by the transaction manager. Closing a connection does NOT
    * force an acknowledgment of client-acknowledged sessions.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>Connection</tt>. Doing so will cause an <tt>IllegalStateException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>Connection</code>. Doing so will cause an <code>IllegalStateException</code> to be
+   * thrown.
    *
    * <p>Invoking the {@code acknowledge} method of a received message from a closed connection's
    * session must throw an {@code IllegalStateException}. Closing a closed connection must NOT throw
@@ -621,10 +622,10 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
    *
    * @throws IllegalStateException
    *     <ul>
-   *       <li>this method has been called by a <tt>MessageListener </tt> on its own
-   *           <tt>Connection</tt>
-   *       <li>this method has been called by a <tt>CompletionListener</tt> callback method on its
-   *           own <tt>Connection</tt>
+   *       <li>this method has been called by a <code>MessageListener </code> on its own <code>
+   *           Connection</code>
+   *       <li>this method has been called by a <code>CompletionListener</code> callback method on
+   *           its own <code>Connection</code>
    *     </ul>
    *
    * @throws JMSException if the JMS provider fails to close the connection due to some internal

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSContext.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSContext.java
@@ -367,8 +367,8 @@ public class PulsarJMSContext implements JMSContext {
    *
    * @throws IllegalStateRuntimeException
    *     <ul>
-   *       <li>if this method has been called by a <tt>MessageListener</tt> on its own
-   *           <tt>JMSContext</tt>
+   *       <li>if this method has been called by a <code>MessageListener</code> on its own <code>
+   *           JMSContext</code>
    *       <li>if the {@code JMSContext} is container-managed (injected).
    *     </ul>
    *
@@ -458,8 +458,8 @@ public class PulsarJMSContext implements JMSContext {
    * portable.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>JMSContext</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
-   * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
+   * <code>JMSContext</code> have been completed and any <code>CompletionListener</code> callbacks
+   * have returned. Incomplete sends should be allowed to complete normally unless an error occurs.
    *
    * <p>For the avoidance of doubt, if an exception listener for the JMSContext's connection is
    * running when {@code close} is invoked, there is no requirement for the {@code close} call to
@@ -476,18 +476,19 @@ public class PulsarJMSContext implements JMSContext {
    * session must throw an {@code IllegalStateRuntimeException}. Closing a closed connection must
    * NOT throw an exception.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>JMSContext</tt>. Doing so will cause an <tt>IllegalStateRuntimeException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>JMSContext</code>. Doing so will cause an <code>IllegalStateRuntimeException</code>
+   * to be thrown.
    *
    * <p>This method must not be used if the {@code JMSContext} is container-managed (injected).
    * Doing so will cause a {@code IllegalStateRuntimeException} to be thrown.
    *
    * @throws IllegalStateRuntimeException
    *     <ul>
-   *       <li>if this method has been called by a <tt>MessageListener </tt> on its own
-   *           <tt>JMSContext</tt>
-   *       <li>if this method has been called by a <tt>CompletionListener</tt> callback method on
-   *           its own <tt>JMSContext</tt>
+   *       <li>if this method has been called by a <code>MessageListener </code> on its own <code>
+   *           JMSContext</code>
+   *       <li>if this method has been called by a <code>CompletionListener</code> callback method
+   *           on its own <code>JMSContext</code>
    *       <li>if the {@code JMSContext} is container-managed (injected)
    *     </ul>
    *
@@ -694,20 +695,21 @@ public class PulsarJMSContext implements JMSContext {
    * Commits all messages done in this transaction and releases any locks currently held.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>JMSContext</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
-   * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
+   * <code>JMSContext</code> have been completed and any <code>CompletionListener</code> callbacks
+   * have returned. Incomplete sends should be allowed to complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>commit</tt> on its own
-   * <tt>JMSContext</tt>. Doing so will cause an <tt>IllegalStateRuntimeException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>commit</code> on its
+   * own <code>JMSContext</code>. Doing so will cause an <code>IllegalStateRuntimeException</code>
+   * to be thrown.
    *
    * <p>This method must not be used if the {@code JMSContext} is container-managed (injected).
    * Doing so will cause a {@code IllegalStateRuntimeException} to be thrown.
    *
    * @throws IllegalStateRuntimeException
    *     <ul>
-   *       <li>if the <tt>JMSContext</tt>'s session is not using a local transaction
-   *       <li>if this method has been called by a <tt> CompletionListener</tt> callback method on
-   *           its own <tt> JMSContext</tt>
+   *       <li>if the <code>JMSContext</code>'s session is not using a local transaction
+   *       <li>if this method has been called by a <code> CompletionListener</code> callback method
+   *           on its own <code> JMSContext</code>
    *       <li>if the {@code JMSContext} is container-managed (injected)
    *     </ul>
    *
@@ -728,20 +730,21 @@ public class PulsarJMSContext implements JMSContext {
    * Rolls back any messages done in this transaction and releases any locks currently held.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>JMSContext</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
-   * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
+   * <code>JMSContext</code> have been completed and any <code>CompletionListener</code> callbacks
+   * have returned. Incomplete sends should be allowed to complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>rollback</tt> on its own
-   * <tt>JMSContext</tt>. Doing so will cause an <tt>IllegalStateRuntimeException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>rollback</code> on its
+   * own <code>JMSContext</code>. Doing so will cause an <code>IllegalStateRuntimeException</code>
+   * to be thrown.
    *
    * <p>This method must not be used if the {@code JMSContext} is container-managed (injected).
    * Doing so will cause a {@code IllegalStateRuntimeException} to be thrown.
    *
    * @throws IllegalStateRuntimeException
    *     <ul>
-   *       <li>if the <tt>JMSContext</tt>'s session is not using a local transaction
-   *       <li>if this method has been called by a <tt>CompletionListener</tt> callback method on
-   *           its own <tt>JMSContext</tt>
+   *       <li>if the <code>JMSContext</code>'s session is not using a local transaction
+   *       <li>if this method has been called by a <code>CompletionListener</code> callback method
+   *           on its own <code>JMSContext</code>
    *       <li>if the {@code JMSContext} is container-managed (injected)
    *     </ul>
    *
@@ -775,7 +778,7 @@ public class PulsarJMSContext implements JMSContext {
    *
    * @throws IllegalStateRuntimeException
    *     <ul>
-   *       <li>if the <tt>JMSContext</tt>'s session is using a transaction
+   *       <li>if the <code>JMSContext</code>'s session is using a transaction
    *       <li>if the {@code JMSContext} is container-managed (injected)
    *     </ul>
    *

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSProducer.java
@@ -444,14 +444,15 @@ public class PulsarJMSProducer implements JMSProducer {
    * {@code send} are synchronous by default.
    *
    * <p>If a call to {@code send} is asynchronous then part of the work involved in sending the
-   * message will be performed in a separate thread and the specified <tt>CompletionListener</tt>
-   * will be notified when the operation has completed.
+   * message will be performed in a separate thread and the specified <code>CompletionListener
+   * </code> will be notified when the operation has completed.
    *
    * <p>When the message has been successfully sent the JMS provider invokes the callback method
-   * <tt>onCompletion</tt> on the <tt>CompletionListener</tt> object. Only when that callback has
-   * been invoked can the application be sure that the message has been successfully sent with the
-   * same degree of confidence as if the send had been synchronous. An application which requires
-   * this degree of confidence must therefore wait for the callback to be invoked before continuing.
+   * <code>onCompletion</code> on the <code>CompletionListener</code> object. Only when that
+   * callback has been invoked can the application be sure that the message has been successfully
+   * sent with the same degree of confidence as if the send had been synchronous. An application
+   * which requires this degree of confidence must therefore wait for the callback to be invoked
+   * before continuing.
    *
    * <p>The following information is intended to give an indication of how an asynchronous send
    * would typically be implemented.
@@ -461,17 +462,18 @@ public class PulsarJMSProducer implements JMSProducer {
    * expected that such a provider would implement an asynchronous send by sending the message to
    * the remote JMS server and then returning without waiting for an acknowledgement. When the
    * acknowledgement is received, the JMS provider would notify the application by invoking the
-   * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
-   * If for some reason the acknowledgement is not received the JMS provider would notify the
-   * application by invoking the <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+   * <code>onCompletion</code> method on the application-specified <code>CompletionListener</code>
+   * object. If for some reason the acknowledgement is not received the JMS provider would notify
+   * the application by invoking the <code>CompletionListener</code>'s <code>onException</code>
+   * method.
    *
    * <p>In those cases where the JMS specification permits a lower level of reliability, a normal
    * synchronous send might not wait for an acknowledgement. In that case it is expected that an
    * asynchronous send would be similar to a synchronous send: the JMS provider would send the
    * message to the remote JMS server and then return without waiting for an acknowledgement.
    * However the JMS provider would still notify the application that the send had completed by
-   * invoking the <tt>onCompletion</tt> method on the application-specified
-   * <tt>CompletionListener</tt> object.
+   * invoking the <code>onCompletion</code> method on the application-specified <code>
+   * CompletionListener</code> object.
    *
    * <p>It is up to the JMS provider to decide exactly what is performed in the calling thread and
    * what, if anything, is performed asynchronously, so long as it satisfies the requirements given
@@ -479,36 +481,37 @@ public class PulsarJMSProducer implements JMSProducer {
    *
    * <p><b>Quality of service</b>: After the send operation has completed successfully, which means
    * that the message has been successfully sent with the same degree of confidence as if a normal
-   * synchronous send had been performed, the JMS provider must invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
-   * must not be invoked earlier than this.
+   * synchronous send had been performed, the JMS provider must invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> method. The <code>CompletionListener</code> must not be
+   * invoked earlier than this.
    *
-   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt>
-   * method then an appropriate exception should be thrown in the thread that is calling the
-   * <tt>send</tt> method. In this case the JMS provider must not invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an
-   * exception is encountered which cannot be thrown in the thread that is calling the <tt>send</tt>
-   * method then the JMS provider must call the <tt>CompletionListener</tt>'s <tt>onException</tt>
+   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <code>send</code>
+   * method then an appropriate exception should be thrown in the thread that is calling the <code>
+   * send</code> method. In this case the JMS provider must not invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> or <code>onException</code> method. If an exception is
+   * encountered which cannot be thrown in the thread that is calling the <code>send</code> method
+   * then the JMS provider must call the <code>CompletionListener</code>'s <code>onException</code>
    * method. In both cases if an exception occurs it is undefined whether or not the message was
    * successfully sent.
    *
-   * <p><b>Message order</b>: If the same <tt>JMSContext</tt> is used to send multiple messages then
-   * JMS message ordering requirements must be satisfied. This applies even if a combination of
+   * <p><b>Message order</b>: If the same <code>JMSContext</code> is used to send multiple messages
+   * then JMS message ordering requirements must be satisfied. This applies even if a combination of
    * synchronous and asynchronous sends has been performed. The application is not required to wait
    * for an asynchronous send to complete before sending the next message.
    *
-   * <p><b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the
-   * <tt>JMSContext</tt> then the JMS provider must block until any incomplete send operations have
+   * <p><b>Close, commit or rollback</b>: If the <code>close</code> method is called on the <code>
+   * JMSContext</code> then the JMS provider must block until any incomplete send operations have
    * been completed and all {@code CompletionListener} callbacks have returned before closing the
    * object and returning. If the session is transacted (uses a local transaction) then when the
-   * <tt>JMSContext</tt>'s <tt>commit</tt> or <tt>rollback</tt> method is called the JMS provider
-   * must block until any incomplete send operations have been completed and all {@code
+   * <code>JMSContext</code>'s <code>commit</code> or <code>rollback</code> method is called the JMS
+   * provider must block until any incomplete send operations have been completed and all {@code
    * CompletionListener} callbacks have returned before performing the commit or rollback.
    * Incomplete sends should be allowed to complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt>, <tt>commit</tt>
-   * or <tt>rollback</tt> on its own <tt>JMSContext</tt>. Doing so will cause the <tt>close</tt>,
-   * <tt>commit</tt> or <tt>rollback</tt> to throw an <tt>IllegalStateRuntimeException</tt>.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code>, <code>
+   * commit</code> or <code>rollback</code> on its own <code>JMSContext</code>. Doing so will cause
+   * the <code>close</code>, <code>commit</code> or <code>rollback</code> to throw an <code>
+   * IllegalStateRuntimeException</code>.
    *
    * <p><b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web
    * container. Doing so may cause a {@code JMSRuntimeException} to be thrown though this is not
@@ -516,40 +519,40 @@ public class PulsarJMSProducer implements JMSProducer {
    *
    * <p><b>Message headers</b> JMS defines a number of message header fields and message properties
    * which must be set by the "JMS provider on send". If the send is asynchronous these fields and
-   * properties may be accessed on the sending client only after the <tt>CompletionListener</tt> has
-   * been invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method is called then
-   * the state of these message header fields and properties is undefined.
+   * properties may be accessed on the sending client only after the <code>CompletionListener</code>
+   * has been invoked. If the <code>CompletionListener</code>'s <code>onException</code> method is
+   * called then the state of these message header fields and properties is undefined.
    *
    * <p><b>Restrictions on threading</b>: Applications that perform an asynchronous send must
    * confirm to the threading restrictions defined in JMS. This means that the session may be used
    * by only one thread at a time.
    *
-   * <p>Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the
-   * thread of control which calls the <tt>CompletionListener</tt>. The application thread may
-   * therefore continue to use the session after performing an asynchronous send. However the
-   * <tt>CompletionListener</tt>'s callback methods must not use the session if an application
-   * thread might be using the session at the same time.
+   * <p>Setting a <code>CompletionListener</code> does not cause the session to be dedicated to the
+   * thread of control which calls the <code>CompletionListener</code>. The application thread may
+   * therefore continue to use the session after performing an asynchronous send. However the <code>
+   * CompletionListener</code>'s callback methods must not use the session if an application thread
+   * might be using the session at the same time.
    *
-   * <p><b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only
-   * invoke one <tt>CompletionListener</tt> callback method at a time. For a given
-   * <tt>JMSContext</tt>, callbacks (both {@code onCompletion} and {@code onException}) will be
-   * performed in the same order as the corresponding calls to the <tt>send</tt> method. A JMS
-   * provider must not invoke the <tt>CompletionListener</tt> from the thread that is calling the
-   * <tt>send</tt> method.
+   * <p><b>Use of the <code>CompletionListener</code> by the JMS provider</b>: A session will only
+   * invoke one <code>CompletionListener</code> callback method at a time. For a given <code>
+   * JMSContext</code>, callbacks (both {@code onCompletion} and {@code onException}) will be
+   * performed in the same order as the corresponding calls to the <code>send</code> method. A JMS
+   * provider must not invoke the <code>CompletionListener</code> from the thread that is calling
+   * the <code>send</code> method.
    *
    * <p><b>Restrictions on the use of the Message object</b>: Applications which perform an
-   * asynchronous send must take account of the restriction that a <tt>Message</tt> object is
+   * asynchronous send must take account of the restriction that a <code>Message</code> object is
    * designed to be accessed by one logical thread of control at a time and does not support
    * concurrent use.
    *
-   * <p>After the <tt>send</tt> method has returned, the application must not attempt to read the
-   * headers, properties or body of the <tt>Message</tt> object until the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method has been
-   * called. This is because the JMS provider may be modifying the <tt>Message</tt> object in
-   * another thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the
-   * application attempts to access or modify the <tt>Message</tt> object after the <tt>send</tt>
-   * method has returned and before the <tt>CompletionListener</tt> has been invoked. If the JMS
-   * provider does not throw an exception then the behaviour is undefined.
+   * <p>After the <code>send</code> method has returned, the application must not attempt to read
+   * the headers, properties or body of the <code>Message</code> object until the <code>
+   * CompletionListener</code>'s <code>onCompletion</code> or <code>onException</code> method has
+   * been called. This is because the JMS provider may be modifying the <code>Message</code> object
+   * in another thread during this time. The JMS provider may throw an <code>JMSException</code> if
+   * the application attempts to access or modify the <code>Message</code> object after the <code>
+   * send</code> method has returned and before the <code>CompletionListener</code> has been
+   * invoked. If the JMS provider does not throw an exception then the behaviour is undefined.
    *
    * @param completionListener If asynchronous send behaviour is required, this should be set to a
    *     {@code CompletionListener} to be notified when the send has completed. If synchronous send

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -329,14 +329,16 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    * garbage collection to eventually reclaim these resources may not be timely enough.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>MessageProducer</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
-   * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
+   * <code>MessageProducer</code> have been completed and any <code>CompletionListener</code>
+   * callbacks have returned. Incomplete sends should be allowed to complete normally unless an
+   * error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>MessageProducer</tt>. Doing so will cause an <tt>IllegalStateException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>MessageProducer</code>. Doing so will cause an <code>IllegalStateException</code> to
+   * be thrown.
    *
-   * @throws IllegalStateException this method has been called by a <tt>CompletionListener</tt>
-   *     callback method on its own <tt>MessageProducer</tt>
+   * @throws IllegalStateException this method has been called by a <code>CompletionListener</code>
+   *     callback method on its own <code>MessageProducer</code>
    * @throws JMSException if the JMS provider fails to close the producer due to some internal
    *     error.
    */
@@ -491,12 +493,12 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
   /**
    * Sends a message using the {@code MessageProducer}'s default delivery mode, priority, and time
    * to live, performing part of the work involved in sending the message in a separate thread and
-   * notifying the specified <tt>CompletionListener</tt> when the operation has completed. JMS
+   * notifying the specified <code>CompletionListener</code> when the operation has completed. JMS
    * refers to this as an "asynchronous send".
    *
    * <p>When the message has been successfully sent the JMS provider invokes the callback method
-   * <tt>onCompletion</tt> on an application-specified <tt>CompletionListener</tt> object. Only when
-   * that callback has been invoked can the application be sure that the message has been
+   * <code>onCompletion</code> on an application-specified <code>CompletionListener</code> object.
+   * Only when that callback has been invoked can the application be sure that the message has been
    * successfully sent with the same degree of confidence as if a normal synchronous send had been
    * performed. An application which requires this degree of confidence must therefore wait for the
    * callback to be invoked before continuing.
@@ -509,17 +511,18 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    * expected that such a provider would implement an asynchronous send by sending the message to
    * the remote JMS server and then returning without waiting for an acknowledgement. When the
    * acknowledgement is received, the JMS provider would notify the application by invoking the
-   * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
-   * If for some reason the acknowledgement is not received the JMS provider would notify the
-   * application by invoking the <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+   * <code>onCompletion</code> method on the application-specified <code>CompletionListener</code>
+   * object. If for some reason the acknowledgement is not received the JMS provider would notify
+   * the application by invoking the <code>CompletionListener</code>'s <code>onException</code>
+   * method.
    *
    * <p>In those cases where the JMS specification permits a lower level of reliability, a normal
    * synchronous send might not wait for an acknowledgement. In that case it is expected that an
    * asynchronous send would be similar to a synchronous send: the JMS provider would send the
    * message to the remote JMS server and then return without waiting for an acknowledgement.
    * However the JMS provider would still notify the application that the send had completed by
-   * invoking the <tt>onCompletion</tt> method on the application-specified
-   * <tt>CompletionListener</tt> object.
+   * invoking the <code>onCompletion</code> method on the application-specified <code>
+   * CompletionListener</code> object.
    *
    * <p>It is up to the JMS provider to decide exactly what is performed in the calling thread and
    * what, if anything, is performed asynchronously, so long as it satisfies the requirements given
@@ -527,38 +530,39 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Quality of service</b>: After the send operation has completed successfully, which means
    * that the message has been successfully sent with the same degree of confidence as if a normal
-   * synchronous send had been performed, the JMS provider must invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
-   * must not be invoked earlier than this.
+   * synchronous send had been performed, the JMS provider must invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> method. The <code>CompletionListener</code> must not be
+   * invoked earlier than this.
    *
-   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt>
-   * method then an appropriate exception should be thrown in the thread that is calling the
-   * <tt>send</tt> method. In this case the JMS provider must not invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an
-   * exception is encountered which cannot be thrown in the thread that is calling the <tt>send</tt>
-   * method then the JMS provider must call the <tt>CompletionListener</tt>'s <tt>onException</tt>
+   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <code>send</code>
+   * method then an appropriate exception should be thrown in the thread that is calling the <code>
+   * send</code> method. In this case the JMS provider must not invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> or <code>onException</code> method. If an exception is
+   * encountered which cannot be thrown in the thread that is calling the <code>send</code> method
+   * then the JMS provider must call the <code>CompletionListener</code>'s <code>onException</code>
    * method. In both cases if an exception occurs it is undefined whether or not the message was
    * successfully sent.
    *
-   * <p><b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages
-   * then JMS message ordering requirements must be satisfied. This applies even if a combination of
-   * synchronous and asynchronous sends has been performed. The application is not required to wait
-   * for an asynchronous send to complete before sending the next message.
+   * <p><b>Message order</b>: If the same <code>MessageProducer</code> is used to send multiple
+   * messages then JMS message ordering requirements must be satisfied. This applies even if a
+   * combination of synchronous and asynchronous sends has been performed. The application is not
+   * required to wait for an asynchronous send to complete before sending the next message.
    *
-   * <p><b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the
-   * <tt>MessageProducer</tt> or its <tt>Session</tt> or <tt>Connection</tt> then the JMS provider
-   * must block until any incomplete send operations have been completed and all {@code
+   * <p><b>Close, commit or rollback</b>: If the <code>close</code> method is called on the <code>
+   * MessageProducer</code> or its <code>Session</code> or <code>Connection</code> then the JMS
+   * provider must block until any incomplete send operations have been completed and all {@code
    * CompletionListener} callbacks have returned before closing the object and returning. If the
-   * session is transacted (uses a local transaction) then when the <tt>Session</tt>'s
-   * <tt>commit</tt> or <tt>rollback</tt> method is called the JMS provider must block until any
+   * session is transacted (uses a local transaction) then when the <code>Session</code>'s <code>
+   * commit</code> or <code>rollback</code> method is called the JMS provider must block until any
    * incomplete send operations have been completed and all {@code CompletionListener} callbacks
    * have returned before performing the commit or rollback. Incomplete sends should be allowed to
    * complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>Connection</tt>, <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or
-   * <tt>rollback</tt> on its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-   * <tt>commit</tt> or <tt>rollback</tt> to throw an <tt>IllegalStateException</tt>.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>Connection</code>, <code>Session</code> or <code>MessageProducer</code> or call
+   * <code>commit</code> or <code>rollback</code> on its own <code>Session</code>. Doing so will
+   * cause the <code>close</code>, <code>commit</code> or <code>rollback</code> to throw an <code>
+   * IllegalStateException</code>.
    *
    * <p><b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web
    * container. Doing so may cause a {@code JMSException} to be thrown though this is not
@@ -566,40 +570,40 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Message headers</b> JMS defines a number of message header fields and message properties
    * which must be set by the "JMS provider on send". If the send is asynchronous these fields and
-   * properties may be accessed on the sending client only after the <tt>CompletionListener</tt> has
-   * been invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method is called then
-   * the state of these message header fields and properties is undefined.
+   * properties may be accessed on the sending client only after the <code>CompletionListener</code>
+   * has been invoked. If the <code>CompletionListener</code>'s <code>onException</code> method is
+   * called then the state of these message header fields and properties is undefined.
    *
    * <p><b>Restrictions on threading</b>: Applications that perform an asynchronous send must
    * confirm to the threading restrictions defined in JMS. This means that the session may be used
    * by only one thread at a time.
    *
-   * <p>Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the
-   * thread of control which calls the <tt>CompletionListener</tt>. The application thread may
-   * therefore continue to use the session after performing an asynchronous send. However the
-   * <tt>CompletionListener</tt>'s callback methods must not use the session if an application
-   * thread might be using the session at the same time.
+   * <p>Setting a <code>CompletionListener</code> does not cause the session to be dedicated to the
+   * thread of control which calls the <code>CompletionListener</code>. The application thread may
+   * therefore continue to use the session after performing an asynchronous send. However the <code>
+   * CompletionListener</code>'s callback methods must not use the session if an application thread
+   * might be using the session at the same time.
    *
-   * <p><b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only
-   * invoke one <tt>CompletionListener</tt> callback method at a time. For a given
-   * <tt>MessageProducer</tt>, callbacks (both {@code onCompletion} and {@code onException}) will be
+   * <p><b>Use of the <code>CompletionListener</code> by the JMS provider</b>: A session will only
+   * invoke one <code>CompletionListener</code> callback method at a time. For a given <code>
+   * MessageProducer</code>, callbacks (both {@code onCompletion} and {@code onException}) will be
    * performed in the same order as the corresponding calls to the asynchronous send method. A JMS
-   * provider must not invoke the <tt>CompletionListener</tt> from the thread that is calling the
-   * asynchronous <tt>send</tt> method.
+   * provider must not invoke the <code>CompletionListener</code> from the thread that is calling
+   * the asynchronous <code>send</code> method.
    *
    * <p><b>Restrictions on the use of the Message object</b>: Applications which perform an
-   * asynchronous send must take account of the restriction that a <tt>Message</tt> object is
+   * asynchronous send must take account of the restriction that a <code>Message</code> object is
    * designed to be accessed by one logical thread of control at a time and does not support
    * concurrent use.
    *
-   * <p>After the <tt>send</tt> method has returned, the application must not attempt to read the
-   * headers, properties or body of the <tt>Message</tt> object until the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method has been
-   * called. This is because the JMS provider may be modifying the <tt>Message</tt> object in
-   * another thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the
-   * application attempts to access or modify the <tt>Message</tt> object after the <tt>send</tt>
-   * method has returned and before the <tt>CompletionListener</tt> has been invoked. If the JMS
-   * provider does not throw an exception then the behaviour is undefined.
+   * <p>After the <code>send</code> method has returned, the application must not attempt to read
+   * the headers, properties or body of the <code>Message</code> object until the <code>
+   * CompletionListener</code>'s <code>onCompletion</code> or <code>onException</code> method has
+   * been called. This is because the JMS provider may be modifying the <code>Message</code> object
+   * in another thread during this time. The JMS provider may throw an <code>JMSException</code> if
+   * the application attempts to access or modify the <code>Message</code> object after the <code>
+   * send</code> method has returned and before the <code>CompletionListener</code> has been
+   * invoked. If the JMS provider does not throw an exception then the behaviour is undefined.
    *
    * @param message the message to send
    * @param completionListener a {@code CompletionListener} to be notified when the send has
@@ -639,13 +643,13 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
 
   /**
    * Sends a message, specifying delivery mode, priority and time to live, performing part of the
-   * work involved in sending the message in a separate thread and notifying the specified
-   * <tt>CompletionListener</tt> when the operation has completed. JMS refers to this as an
+   * work involved in sending the message in a separate thread and notifying the specified <code>
+   * CompletionListener</code> when the operation has completed. JMS refers to this as an
    * "asynchronous send".
    *
    * <p>When the message has been successfully sent the JMS provider invokes the callback method
-   * <tt>onCompletion</tt> on an application-specified <tt>CompletionListener</tt> object. Only when
-   * that callback has been invoked can the application be sure that the message has been
+   * <code>onCompletion</code> on an application-specified <code>CompletionListener</code> object.
+   * Only when that callback has been invoked can the application be sure that the message has been
    * successfully sent with the same degree of confidence as if a normal synchronous send had been
    * performed. An application which requires this degree of confidence must therefore wait for the
    * callback to be invoked before continuing.
@@ -658,17 +662,18 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    * expected that such a provider would implement an asynchronous send by sending the message to
    * the remote JMS server and then returning without waiting for an acknowledgement. When the
    * acknowledgement is received, the JMS provider would notify the application by invoking the
-   * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
-   * If for some reason the acknowledgement is not received the JMS provider would notify the
-   * application by invoking the <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+   * <code>onCompletion</code> method on the application-specified <code>CompletionListener</code>
+   * object. If for some reason the acknowledgement is not received the JMS provider would notify
+   * the application by invoking the <code>CompletionListener</code>'s <code>onException</code>
+   * method.
    *
    * <p>In those cases where the JMS specification permits a lower level of reliability, a normal
    * synchronous send might not wait for an acknowledgement. In that case it is expected that an
    * asynchronous send would be similar to a synchronous send: the JMS provider would send the
    * message to the remote JMS server and then return without waiting for an acknowledgement.
    * However the JMS provider would still notify the application that the send had completed by
-   * invoking the <tt>onCompletion</tt> method on the application-specified
-   * <tt>CompletionListener</tt> object.
+   * invoking the <code>onCompletion</code> method on the application-specified <code>
+   * CompletionListener</code> object.
    *
    * <p>It is up to the JMS provider to decide exactly what is performed in the calling thread and
    * what, if anything, is performed asynchronously, so long as it satisfies the requirements given
@@ -676,38 +681,39 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Quality of service</b>: After the send operation has completed successfully, which means
    * that the message has been successfully sent with the same degree of confidence as if a normal
-   * synchronous send had been performed, the JMS provider must invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
-   * must not be invoked earlier than this.
+   * synchronous send had been performed, the JMS provider must invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> method. The <code>CompletionListener</code> must not be
+   * invoked earlier than this.
    *
-   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt>
-   * method then an appropriate exception should be thrown in the thread that is calling the
-   * <tt>send</tt> method. In this case the JMS provider must not invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an
-   * exception is encountered which cannot be thrown in the thread that is calling the <tt>send</tt>
-   * method then the JMS provider must call the <tt>CompletionListener</tt>'s <tt>onException</tt>
+   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <code>send</code>
+   * method then an appropriate exception should be thrown in the thread that is calling the <code>
+   * send</code> method. In this case the JMS provider must not invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> or <code>onException</code> method. If an exception is
+   * encountered which cannot be thrown in the thread that is calling the <code>send</code> method
+   * then the JMS provider must call the <code>CompletionListener</code>'s <code>onException</code>
    * method. In both cases if an exception occurs it is undefined whether or not the message was
    * successfully sent.
    *
-   * <p><b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages
-   * then JMS message ordering requirements must be satisfied. This applies even if a combination of
-   * synchronous and asynchronous sends has been performed. The application is not required to wait
-   * for an asynchronous send to complete before sending the next message.
+   * <p><b>Message order</b>: If the same <code>MessageProducer</code> is used to send multiple
+   * messages then JMS message ordering requirements must be satisfied. This applies even if a
+   * combination of synchronous and asynchronous sends has been performed. The application is not
+   * required to wait for an asynchronous send to complete before sending the next message.
    *
-   * <p><b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the
-   * <tt>MessageProducer</tt> or its <tt>Session</tt> or <tt>Connection</tt> then the JMS provider
-   * must block until any incomplete send operations have been completed and all {@code
+   * <p><b>Close, commit or rollback</b>: If the <code>close</code> method is called on the <code>
+   * MessageProducer</code> or its <code>Session</code> or <code>Connection</code> then the JMS
+   * provider must block until any incomplete send operations have been completed and all {@code
    * CompletionListener} callbacks have returned before closing the object and returning. If the
-   * session is transacted (uses a local transaction) then when the <tt>Session</tt>'s
-   * <tt>commit</tt> or <tt>rollback</tt> method is called the JMS provider must block until any
+   * session is transacted (uses a local transaction) then when the <code>Session</code>'s <code>
+   * commit</code> or <code>rollback</code> method is called the JMS provider must block until any
    * incomplete send operations have been completed and all {@code CompletionListener} callbacks
    * have returned before performing the commit or rollback. Incomplete sends should be allowed to
    * complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>Connection</tt>, <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or
-   * <tt>rollback</tt> on its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-   * <tt>commit</tt> or <tt>rollback</tt> to throw an <tt>IllegalStateException</tt>.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>Connection</code>, <code>Session</code> or <code>MessageProducer</code> or call
+   * <code>commit</code> or <code>rollback</code> on its own <code>Session</code>. Doing so will
+   * cause the <code>close</code>, <code>commit</code> or <code>rollback</code> to throw an <code>
+   * IllegalStateException</code>.
    *
    * <p><b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web
    * container. Doing so may cause a {@code JMSException} to be thrown though this is not
@@ -715,40 +721,40 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Message headers</b> JMS defines a number of message header fields and message properties
    * which must be set by the "JMS provider on send". If the send is asynchronous these fields and
-   * properties may be accessed on the sending client only after the <tt>CompletionListener</tt> has
-   * been invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method is called then
-   * the state of these message header fields and properties is undefined.
+   * properties may be accessed on the sending client only after the <code>CompletionListener</code>
+   * has been invoked. If the <code>CompletionListener</code>'s <code>onException</code> method is
+   * called then the state of these message header fields and properties is undefined.
    *
    * <p><b>Restrictions on threading</b>: Applications that perform an asynchronous send must
    * confirm to the threading restrictions defined in JMS. This means that the session may be used
    * by only one thread at a time.
    *
-   * <p>Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the
-   * thread of control which calls the <tt>CompletionListener</tt>. The application thread may
-   * therefore continue to use the session after performing an asynchronous send. However the
-   * <tt>CompletionListener</tt>'s callback methods must not use the session if an application
-   * thread might be using the session at the same time.
+   * <p>Setting a <code>CompletionListener</code> does not cause the session to be dedicated to the
+   * thread of control which calls the <code>CompletionListener</code>. The application thread may
+   * therefore continue to use the session after performing an asynchronous send. However the <code>
+   * CompletionListener</code>'s callback methods must not use the session if an application thread
+   * might be using the session at the same time.
    *
-   * <p><b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only
-   * invoke one <tt>CompletionListener</tt> callback method at a time. For a given
-   * <tt>MessageProducer</tt>, callbacks (both {@code onCompletion} and {@code onException}) will be
+   * <p><b>Use of the <code>CompletionListener</code> by the JMS provider</b>: A session will only
+   * invoke one <code>CompletionListener</code> callback method at a time. For a given <code>
+   * MessageProducer</code>, callbacks (both {@code onCompletion} and {@code onException}) will be
    * performed in the same order as the corresponding calls to the asynchronous send method. A JMS
-   * provider must not invoke the <tt>CompletionListener</tt> from the thread that is calling the
-   * asynchronous <tt>send</tt> method.
+   * provider must not invoke the <code>CompletionListener</code> from the thread that is calling
+   * the asynchronous <code>send</code> method.
    *
    * <p><b>Restrictions on the use of the Message object</b>: Applications which perform an
-   * asynchronous send must take account of the restriction that a <tt>Message</tt> object is
+   * asynchronous send must take account of the restriction that a <code>Message</code> object is
    * designed to be accessed by one logical thread of control at a time and does not support
    * concurrent use.
    *
-   * <p>After the <tt>send</tt> method has returned, the application must not attempt to read the
-   * headers, properties or body of the <tt>Message</tt> object until the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method has been
-   * called. This is because the JMS provider may be modifying the <tt>Message</tt> object in
-   * another thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the
-   * application attempts to access or modify the <tt>Message</tt> object after the <tt>send</tt>
-   * method has returned and before the <tt>CompletionListener</tt> has been invoked. If the JMS
-   * provider does not throw an exception then the behaviour is undefined.
+   * <p>After the <code>send</code> method has returned, the application must not attempt to read
+   * the headers, properties or body of the <code>Message</code> object until the <code>
+   * CompletionListener</code>'s <code>onCompletion</code> or <code>onException</code> method has
+   * been called. This is because the JMS provider may be modifying the <code>Message</code> object
+   * in another thread during this time. The JMS provider may throw an <code>JMSException</code> if
+   * the application attempts to access or modify the <code>Message</code> object after the <code>
+   * send</code> method has returned and before the <code>CompletionListener</code> has been
+   * invoked. If the JMS provider does not throw an exception then the behaviour is undefined.
    *
    * @param message the message to send
    * @param deliveryMode the delivery mode to use
@@ -863,8 +869,8 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
   /**
    * Sends a message to a destination for an unidentified message producer, using the {@code
    * MessageProducer}'s default delivery mode, priority, and time to live, performing part of the
-   * work involved in sending the message in a separate thread and notifying the specified
-   * <tt>CompletionListener</tt> when the operation has completed. JMS refers to this as an
+   * work involved in sending the message in a separate thread and notifying the specified <code>
+   * CompletionListener</code> when the operation has completed. JMS refers to this as an
    * "asynchronous send".
    *
    * <p>Typically, a message producer is assigned a destination at creation time; however, the JMS
@@ -872,8 +878,8 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    * supplied every time a message is sent.
    *
    * <p>When the message has been successfully sent the JMS provider invokes the callback method
-   * <tt>onCompletion</tt> on an application-specified <tt>CompletionListener</tt> object. Only when
-   * that callback has been invoked can the application be sure that the message has been
+   * <code>onCompletion</code> on an application-specified <code>CompletionListener</code> object.
+   * Only when that callback has been invoked can the application be sure that the message has been
    * successfully sent with the same degree of confidence as if a normal synchronous send had been
    * performed. An application which requires this degree of confidence must therefore wait for the
    * callback to be invoked before continuing.
@@ -886,17 +892,18 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    * expected that such a provider would implement an asynchronous send by sending the message to
    * the remote JMS server and then returning without waiting for an acknowledgement. When the
    * acknowledgement is received, the JMS provider would notify the application by invoking the
-   * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
-   * If for some reason the acknowledgement is not received the JMS provider would notify the
-   * application by invoking the <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+   * <code>onCompletion</code> method on the application-specified <code>CompletionListener</code>
+   * object. If for some reason the acknowledgement is not received the JMS provider would notify
+   * the application by invoking the <code>CompletionListener</code>'s <code>onException</code>
+   * method.
    *
    * <p>In those cases where the JMS specification permits a lower level of reliability, a normal
    * synchronous send might not wait for an acknowledgement. In that case it is expected that an
    * asynchronous send would be similar to a synchronous send: the JMS provider would send the
    * message to the remote JMS server and then return without waiting for an acknowledgement.
    * However the JMS provider would still notify the application that the send had completed by
-   * invoking the <tt>onCompletion</tt> method on the application-specified
-   * <tt>CompletionListener</tt> object.
+   * invoking the <code>onCompletion</code> method on the application-specified <code>
+   * CompletionListener</code> object.
    *
    * <p>It is up to the JMS provider to decide exactly what is performed in the calling thread and
    * what, if anything, is performed asynchronously, so long as it satisfies the requirements given
@@ -904,38 +911,39 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Quality of service</b>: After the send operation has completed successfully, which means
    * that the message has been successfully sent with the same degree of confidence as if a normal
-   * synchronous send had been performed, the JMS provider must invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
-   * must not be invoked earlier than this.
+   * synchronous send had been performed, the JMS provider must invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> method. The <code>CompletionListener</code> must not be
+   * invoked earlier than this.
    *
-   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt>
-   * method then an appropriate exception should be thrown in the thread that is calling the
-   * <tt>send</tt> method. In this case the JMS provider must not invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an
-   * exception is encountered which cannot be thrown in the thread that is calling the <tt>send</tt>
-   * method then the JMS provider must call the <tt>CompletionListener</tt>'s <tt>onException</tt>
+   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <code>send</code>
+   * method then an appropriate exception should be thrown in the thread that is calling the <code>
+   * send</code> method. In this case the JMS provider must not invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> or <code>onException</code> method. If an exception is
+   * encountered which cannot be thrown in the thread that is calling the <code>send</code> method
+   * then the JMS provider must call the <code>CompletionListener</code>'s <code>onException</code>
    * method. In both cases if an exception occurs it is undefined whether or not the message was
    * successfully sent.
    *
-   * <p><b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages
-   * then JMS message ordering requirements must be satisfied. This applies even if a combination of
-   * synchronous and asynchronous sends has been performed. The application is not required to wait
-   * for an asynchronous send to complete before sending the next message.
+   * <p><b>Message order</b>: If the same <code>MessageProducer</code> is used to send multiple
+   * messages then JMS message ordering requirements must be satisfied. This applies even if a
+   * combination of synchronous and asynchronous sends has been performed. The application is not
+   * required to wait for an asynchronous send to complete before sending the next message.
    *
-   * <p><b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the
-   * <tt>MessageProducer</tt> or its <tt>Session</tt> or <tt>Connection</tt> then the JMS provider
-   * must block until any incomplete send operations have been completed and all {@code
+   * <p><b>Close, commit or rollback</b>: If the <code>close</code> method is called on the <code>
+   * MessageProducer</code> or its <code>Session</code> or <code>Connection</code> then the JMS
+   * provider must block until any incomplete send operations have been completed and all {@code
    * CompletionListener} callbacks have returned before closing the object and returning. If the
-   * session is transacted (uses a local transaction) then when the <tt>Session</tt>'s
-   * <tt>commit</tt> or <tt>rollback</tt> method is called the JMS provider must block until any
+   * session is transacted (uses a local transaction) then when the <code>Session</code>'s <code>
+   * commit</code> or <code>rollback</code> method is called the JMS provider must block until any
    * incomplete send operations have been completed and all {@code CompletionListener} callbacks
    * have returned before performing the commit or rollback. Incomplete sends should be allowed to
    * complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>Connection</tt>, <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or
-   * <tt>rollback</tt> on its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-   * <tt>commit</tt> or <tt>rollback</tt> to throw an <tt>IllegalStateException</tt>.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>Connection</code>, <code>Session</code> or <code>MessageProducer</code> or call
+   * <code>commit</code> or <code>rollback</code> on its own <code>Session</code>. Doing so will
+   * cause the <code>close</code>, <code>commit</code> or <code>rollback</code> to throw an <code>
+   * IllegalStateException</code>.
    *
    * <p><b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web
    * container. Doing so may cause a {@code JMSException} to be thrown though this is not
@@ -943,40 +951,40 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Message headers</b> JMS defines a number of message header fields and message properties
    * which must be set by the "JMS provider on send". If the send is asynchronous these fields and
-   * properties may be accessed on the sending client only after the <tt>CompletionListener</tt> has
-   * been invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method is called then
-   * the state of these message header fields and properties is undefined.
+   * properties may be accessed on the sending client only after the <code>CompletionListener</code>
+   * has been invoked. If the <code>CompletionListener</code>'s <code>onException</code> method is
+   * called then the state of these message header fields and properties is undefined.
    *
    * <p><b>Restrictions on threading</b>: Applications that perform an asynchronous send must
    * confirm to the threading restrictions defined in JMS. This means that the session may be used
    * by only one thread at a time.
    *
-   * <p>Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the
-   * thread of control which calls the <tt>CompletionListener</tt>. The application thread may
-   * therefore continue to use the session after performing an asynchronous send. However the
-   * <tt>CompletionListener</tt>'s callback methods must not use the session if an application
-   * thread might be using the session at the same time.
+   * <p>Setting a <code>CompletionListener</code> does not cause the session to be dedicated to the
+   * thread of control which calls the <code>CompletionListener</code>. The application thread may
+   * therefore continue to use the session after performing an asynchronous send. However the <code>
+   * CompletionListener</code>'s callback methods must not use the session if an application thread
+   * might be using the session at the same time.
    *
-   * <p><b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only
-   * invoke one <tt>CompletionListener</tt> callback method at a time. For a given
-   * <tt>MessageProducer</tt>, callbacks (both {@code onCompletion} and {@code onException}) will be
+   * <p><b>Use of the <code>CompletionListener</code> by the JMS provider</b>: A session will only
+   * invoke one <code>CompletionListener</code> callback method at a time. For a given <code>
+   * MessageProducer</code>, callbacks (both {@code onCompletion} and {@code onException}) will be
    * performed in the same order as the corresponding calls to the asynchronous send method. A JMS
-   * provider must not invoke the <tt>CompletionListener</tt> from the thread that is calling the
-   * asynchronous <tt>send</tt> method.
+   * provider must not invoke the <code>CompletionListener</code> from the thread that is calling
+   * the asynchronous <code>send</code> method.
    *
    * <p><b>Restrictions on the use of the Message object</b>: Applications which perform an
-   * asynchronous send must take account of the restriction that a <tt>Message</tt> object is
+   * asynchronous send must take account of the restriction that a <code>Message</code> object is
    * designed to be accessed by one logical thread of control at a time and does not support
    * concurrent use.
    *
-   * <p>After the <tt>send</tt> method has returned, the application must not attempt to read the
-   * headers, properties or body of the <tt>Message</tt> object until the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method has been
-   * called. This is because the JMS provider may be modifying the <tt>Message</tt> object in
-   * another thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the
-   * application attempts to access or modify the <tt>Message</tt> object after the <tt>send</tt>
-   * method has returned and before the <tt>CompletionListener</tt> has been invoked. If the JMS
-   * provider does not throw an exception then the behaviour is undefined.
+   * <p>After the <code>send</code> method has returned, the application must not attempt to read
+   * the headers, properties or body of the <code>Message</code> object until the <code>
+   * CompletionListener</code>'s <code>onCompletion</code> or <code>onException</code> method has
+   * been called. This is because the JMS provider may be modifying the <code>Message</code> object
+   * in another thread during this time. The JMS provider may throw an <code>JMSException</code> if
+   * the application attempts to access or modify the <code>Message</code> object after the <code>
+   * send</code> method has returned and before the <code>CompletionListener</code> has been
+   * invoked. If the JMS provider does not throw an exception then the behaviour is undefined.
    *
    * @param destination the destination to send this message to
    * @param message the message to send
@@ -1016,16 +1024,16 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
   /**
    * Sends a message to a destination for an unidentified message producer, specifying delivery
    * mode, priority and time to live, performing part of the work involved in sending the message in
-   * a separate thread and notifying the specified <tt>CompletionListener</tt> when the operation
-   * has completed. JMS refers to this as an "asynchronous send".
+   * a separate thread and notifying the specified <code>CompletionListener</code> when the
+   * operation has completed. JMS refers to this as an "asynchronous send".
    *
    * <p>Typically, a message producer is assigned a destination at creation time; however, the JMS
    * API also supports unidentified message producers, which require that the destination be
    * supplied every time a message is sent.
    *
    * <p>When the message has been successfully sent the JMS provider invokes the callback method
-   * <tt>onCompletion</tt> on an application-specified <tt>CompletionListener</tt> object. Only when
-   * that callback has been invoked can the application be sure that the message has been
+   * <code>onCompletion</code> on an application-specified <code>CompletionListener</code> object.
+   * Only when that callback has been invoked can the application be sure that the message has been
    * successfully sent with the same degree of confidence as if a normal synchronous send had been
    * performed. An application which requires this degree of confidence must therefore wait for the
    * callback to be invoked before continuing.
@@ -1038,17 +1046,18 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    * expected that such a provider would implement an asynchronous send by sending the message to
    * the remote JMS server and then returning without waiting for an acknowledgement. When the
    * acknowledgement is received, the JMS provider would notify the application by invoking the
-   * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
-   * If for some reason the acknowledgement is not received the JMS provider would notify the
-   * application by invoking the <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+   * <code>onCompletion</code> method on the application-specified <code>CompletionListener</code>
+   * object. If for some reason the acknowledgement is not received the JMS provider would notify
+   * the application by invoking the <code>CompletionListener</code>'s <code>onException</code>
+   * method.
    *
    * <p>In those cases where the JMS specification permits a lower level of reliability, a normal
    * synchronous send might not wait for an acknowledgement. In that case it is expected that an
    * asynchronous send would be similar to a synchronous send: the JMS provider would send the
    * message to the remote JMS server and then return without waiting for an acknowledgement.
    * However the JMS provider would still notify the application that the send had completed by
-   * invoking the <tt>onCompletion</tt> method on the application-specified
-   * <tt>CompletionListener</tt> object.
+   * invoking the <code>onCompletion</code> method on the application-specified <code>
+   * CompletionListener</code> object.
    *
    * <p>It is up to the JMS provider to decide exactly what is performed in the calling thread and
    * what, if anything, is performed asynchronously, so long as it satisfies the requirements given
@@ -1056,38 +1065,39 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Quality of service</b>: After the send operation has completed successfully, which means
    * that the message has been successfully sent with the same degree of confidence as if a normal
-   * synchronous send had been performed, the JMS provider must invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
-   * must not be invoked earlier than this.
+   * synchronous send had been performed, the JMS provider must invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> method. The <code>CompletionListener</code> must not be
+   * invoked earlier than this.
    *
-   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt>
-   * method then an appropriate exception should be thrown in the thread that is calling the
-   * <tt>send</tt> method. In this case the JMS provider must not invoke the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an
-   * exception is encountered which cannot be thrown in the thread that is calling the <tt>send</tt>
-   * method then the JMS provider must call the <tt>CompletionListener</tt>'s <tt>onException</tt>
+   * <p><b>Exceptions</b>: If an exception is encountered during the call to the <code>send</code>
+   * method then an appropriate exception should be thrown in the thread that is calling the <code>
+   * send</code> method. In this case the JMS provider must not invoke the <code>CompletionListener
+   * </code>'s <code>onCompletion</code> or <code>onException</code> method. If an exception is
+   * encountered which cannot be thrown in the thread that is calling the <code>send</code> method
+   * then the JMS provider must call the <code>CompletionListener</code>'s <code>onException</code>
    * method. In both cases if an exception occurs it is undefined whether or not the message was
    * successfully sent.
    *
-   * <p><b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages
-   * then JMS message ordering requirements must be satisfied. This applies even if a combination of
-   * synchronous and asynchronous sends has been performed. The application is not required to wait
-   * for an asynchronous send to complete before sending the next message.
+   * <p><b>Message order</b>: If the same <code>MessageProducer</code> is used to send multiple
+   * messages then JMS message ordering requirements must be satisfied. This applies even if a
+   * combination of synchronous and asynchronous sends has been performed. The application is not
+   * required to wait for an asynchronous send to complete before sending the next message.
    *
-   * <p><b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the
-   * <tt>MessageProducer</tt> or its <tt>Session</tt> or <tt>Connection</tt> then the JMS provider
-   * must block until any incomplete send operations have been completed and all {@code
+   * <p><b>Close, commit or rollback</b>: If the <code>close</code> method is called on the <code>
+   * MessageProducer</code> or its <code>Session</code> or <code>Connection</code> then the JMS
+   * provider must block until any incomplete send operations have been completed and all {@code
    * CompletionListener} callbacks have returned before closing the object and returning. If the
-   * session is transacted (uses a local transaction) then when the <tt>Session</tt>'s
-   * <tt>commit</tt> or <tt>rollback</tt> method is called the JMS provider must block until any
+   * session is transacted (uses a local transaction) then when the <code>Session</code>'s <code>
+   * commit</code> or <code>rollback</code> method is called the JMS provider must block until any
    * incomplete send operations have been completed and all {@code CompletionListener} callbacks
    * have returned before performing the commit or rollback. Incomplete sends should be allowed to
    * complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>Connection</tt>, <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or
-   * <tt>rollback</tt> on its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-   * <tt>commit</tt> or <tt>rollback</tt> to throw an <tt>IllegalStateException</tt>.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>Connection</code>, <code>Session</code> or <code>MessageProducer</code> or call
+   * <code>commit</code> or <code>rollback</code> on its own <code>Session</code>. Doing so will
+   * cause the <code>close</code>, <code>commit</code> or <code>rollback</code> to throw an <code>
+   * IllegalStateException</code>.
    *
    * <p><b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web
    * container. Doing so may cause a {@code JMSException} to be thrown though this is not
@@ -1095,40 +1105,40 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
    *
    * <p><b>Message headers</b> JMS defines a number of message header fields and message properties
    * which must be set by the "JMS provider on send". If the send is asynchronous these fields and
-   * properties may be accessed on the sending client only after the <tt>CompletionListener</tt> has
-   * been invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method is called then
-   * the state of these message header fields and properties is undefined.
+   * properties may be accessed on the sending client only after the <code>CompletionListener</code>
+   * has been invoked. If the <code>CompletionListener</code>'s <code>onException</code> method is
+   * called then the state of these message header fields and properties is undefined.
    *
    * <p><b>Restrictions on threading</b>: Applications that perform an asynchronous send must
    * confirm to the threading restrictions defined in JMS. This means that the session may be used
    * by only one thread at a time.
    *
-   * <p>Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the
-   * thread of control which calls the <tt>CompletionListener</tt>. The application thread may
-   * therefore continue to use the session after performing an asynchronous send. However the
-   * <tt>CompletionListener</tt>'s callback methods must not use the session if an application
-   * thread might be using the session at the same time.
+   * <p>Setting a <code>CompletionListener</code> does not cause the session to be dedicated to the
+   * thread of control which calls the <code>CompletionListener</code>. The application thread may
+   * therefore continue to use the session after performing an asynchronous send. However the <code>
+   * CompletionListener</code>'s callback methods must not use the session if an application thread
+   * might be using the session at the same time.
    *
-   * <p><b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only
-   * invoke one <tt>CompletionListener</tt> callback method at a time. For a given
-   * <tt>MessageProducer</tt>, callbacks (both {@code onCompletion} and {@code onException}) will be
+   * <p><b>Use of the <code>CompletionListener</code> by the JMS provider</b>: A session will only
+   * invoke one <code>CompletionListener</code> callback method at a time. For a given <code>
+   * MessageProducer</code>, callbacks (both {@code onCompletion} and {@code onException}) will be
    * performed in the same order as the corresponding calls to the asynchronous send method. A JMS
-   * provider must not invoke the <tt>CompletionListener</tt> from the thread that is calling the
-   * asynchronous <tt>send</tt> method.
+   * provider must not invoke the <code>CompletionListener</code> from the thread that is calling
+   * the asynchronous <code>send</code> method.
    *
    * <p><b>Restrictions on the use of the Message object</b>: Applications which perform an
-   * asynchronous send must take account of the restriction that a <tt>Message</tt> object is
+   * asynchronous send must take account of the restriction that a <code>Message</code> object is
    * designed to be accessed by one logical thread of control at a time and does not support
    * concurrent use.
    *
-   * <p>After the <tt>send</tt> method has returned, the application must not attempt to read the
-   * headers, properties or body of the <tt>Message</tt> object until the
-   * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method has been
-   * called. This is because the JMS provider may be modifying the <tt>Message</tt> object in
-   * another thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the
-   * application attempts to access or modify the <tt>Message</tt> object after the <tt>send</tt>
-   * method has returned and before the <tt>CompletionListener</tt> has been invoked. If the JMS
-   * provider does not throw an exception then the behaviour is undefined.
+   * <p>After the <code>send</code> method has returned, the application must not attempt to read
+   * the headers, properties or body of the <code>Message</code> object until the <code>
+   * CompletionListener</code>'s <code>onCompletion</code> or <code>onException</code> method has
+   * been called. This is because the JMS provider may be modifying the <code>Message</code> object
+   * in another thread during this time. The JMS provider may throw an <code>JMSException</code> if
+   * the application attempts to access or modify the <code>Message</code> object after the <code>
+   * send</code> method has returned and before the <code>CompletionListener</code> has been
+   * invoked. If the JMS provider does not throw an exception then the behaviour is undefined.
    *
    * @param destination the destination to send this message to
    * @param message the message to send

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -537,17 +537,18 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
    * Commits all messages done in this transaction and releases any locks currently held.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>Session</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
+   * <code>Session</code> have been completed and any <code>CompletionListener</code> callbacks have
    * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>commit</tt> on its own
-   * <tt>Session</tt>. Doing so will cause an <tt>IllegalStateException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>commit</code> on its
+   * own <code>Session</code>. Doing so will cause an <code>IllegalStateException</code> to be
+   * thrown.
    *
    * @throws IllegalStateException
    *     <ul>
    *       <li>the session is not using a local transaction
-   *       <li>this method has been called by a <tt>CompletionListener</tt> callback method on its
-   *           own <tt>Session</tt>
+   *       <li>this method has been called by a <code>CompletionListener</code> callback method on
+   *           its own <code>Session</code>
    *     </ul>
    *
    * @throws JMSException if the JMS provider fails to commit the transaction due to some internal
@@ -601,17 +602,18 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
    * Rolls back any messages done in this transaction and releases any locks currently held.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>Session</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
+   * <code>Session</code> have been completed and any <code>CompletionListener</code> callbacks have
    * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>commit</tt> on its own
-   * <tt>Session</tt>. Doing so will cause an <tt>IllegalStateException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>commit</code> on its
+   * own <code>Session</code>. Doing so will cause an <code>IllegalStateException</code> to be
+   * thrown.
    *
    * @throws IllegalStateException
    *     <ul>
    *       <li>the session is not using a local transaction
-   *       <li>this method has been called by a <tt>CompletionListener</tt> callback method on its
-   *           own <tt>Session</tt>
+   *       <li>this method has been called by a <code>CompletionListener</code> callback method on
+   *           its own <code>Session</code>
    *     </ul>
    *
    * @throws JMSException if the JMS provider fails to roll back the transaction due to some
@@ -679,7 +681,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
    * calling close from a message listener on its own {@code Session} because this is not portable.
    *
    * <p>This method must not return until any incomplete asynchronous send operations for this
-   * <tt>Session</tt> have been completed and any <tt>CompletionListener</tt> callbacks have
+   * <code>Session</code> have been completed and any <code>CompletionListener</code> callbacks have
    * returned. Incomplete sends should be allowed to complete normally unless an error occurs.
    *
    * <p>For the avoidance of doubt, if an exception listener for this session's connection is
@@ -690,18 +692,19 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
    *
    * <p>This method is the only {@code Session} method that can be called concurrently.
    *
-   * <p>A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own
-   * <tt>Session</tt>. Doing so will cause an <tt>IllegalStateException</tt> to be thrown.
+   * <p>A <code>CompletionListener</code> callback method must not call <code>close</code> on its
+   * own <code>Session</code>. Doing so will cause an <code>IllegalStateException</code> to be
+   * thrown.
    *
    * <p>Invoking any other {@code Session} method on a closed session must throw a {@code
    * IllegalStateException}. Closing a closed session must <I>not</I> throw an exception.
    *
    * @throws IllegalStateException
    *     <ul>
-   *       <li>this method has been called by a <tt>MessageListener </tt> on its own
-   *           <tt>Session</tt>
-   *       <li>this method has been called by a <tt>CompletionListener</tt> callback method on its
-   *           own <tt>Session</tt>
+   *       <li>this method has been called by a <code>MessageListener </code> on its own <code>
+   *           Session</code>
+   *       <li>this method has been called by a <code>CompletionListener</code> callback method on
+   *           its own <code>Session</code>
    *     </ul>
    *
    * @throws JMSException if the JMS provider fails to close the session due to some internal error.

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/TopicDiscoveryUtils.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/TopicDiscoveryUtils.java
@@ -42,8 +42,10 @@ public class TopicDiscoveryUtils {
     try {
       List<String> list =
           lookup
-              .getTopicsUnderNamespace(namespaceName, CommandGetTopicsOfNamespace.Mode.PERSISTENT)
-              .get(timeout, TimeUnit.MILLISECONDS);
+              .getTopicsUnderNamespace(
+                  namespaceName, CommandGetTopicsOfNamespace.Mode.PERSISTENT, null, null)
+              .get(timeout, TimeUnit.MILLISECONDS)
+              .getTopics();
       return topicsPatternFilter(list, Pattern.compile(regex));
     } catch (InterruptedException | TimeoutException | ExecutionException err) {
       throw Utils.handleException(err);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/Utils.java
@@ -47,7 +47,7 @@ import javax.jms.TransactionRolledBackException;
 import javax.jms.TransactionRolledBackRuntimeException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.api.MessageIdAdv;
 
 @Slf4j
 public final class Utils {
@@ -342,8 +342,8 @@ public final class Utils {
 
   public static boolean sameEntryId(MessageId a, MessageId b) {
     // get rid of TopicMessageIdImpl
-    MessageIdImpl a1 = MessageIdImpl.convertToMessageIdImpl(a);
-    MessageIdImpl b1 = MessageIdImpl.convertToMessageIdImpl(b);
+    MessageIdAdv a1 = (MessageIdAdv) a;
+    MessageIdAdv b1 = (MessageIdAdv) b;
     return a1.getLedgerId() == b1.getLedgerId() && a1.getEntryId() == b1.getEntryId();
   }
 

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PriorityTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PriorityTest.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -69,7 +70,7 @@ public class PriorityTest {
             tempDir,
             config -> {
               config.setAllowAutoTopicCreation(true);
-              config.setAllowAutoTopicCreationType("partitioned");
+              config.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
               config.setDefaultNumPartitions(10);
               config.setTransactionCoordinatorEnabled(false);
             });

--- a/resource-adapter-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/PulsarContainer.java
+++ b/resource-adapter-tests/src/test/java/com/datastax/oss/pulsar/jms/tests/PulsarContainer.java
@@ -25,7 +25,7 @@ import org.testcontainers.containers.Network;
 public class PulsarContainer implements AutoCloseable {
 
   private static final String TEST_PULSAR_DOCKER_IMAGE_NAME =
-      System.getProperty("testResourceAdapterPulsarDockerImageName", "apachepulsar/pulsar:2.10.0");
+      System.getProperty("testResourceAdapterPulsarDockerImageName", "apachepulsar/pulsar:3.0.0");
 
   private GenericContainer<?> pulsarContainer;
   private final Network network;

--- a/tck-executor/src/main/java/com/datastax/oss/pulsar/jms/tests/JNDIInitialContextFactory.java
+++ b/tck-executor/src/main/java/com/datastax/oss/pulsar/jms/tests/JNDIInitialContextFactory.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.spi.InitialContextFactory;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 
 public class JNDIInitialContextFactory implements InitialContextFactory {
 
@@ -126,7 +127,12 @@ public class JNDIInitialContextFactory implements InitialContextFactory {
           String topicName = "persistent://public/default/" + name;
           PulsarConnectionFactory tmp = getAdminConnectionFactory();
           System.out.println(this.getClass() + " Cleaning up QUEUE " + topicName);
-          tmp.getPulsarAdmin().topics().delete(topicName, true, true);
+          try {
+            tmp.getPulsarAdmin().topics().delete(topicName, true, true);
+          } catch (PulsarAdminException.NotFoundException ok) {
+            // Since Pulsar 3.0 we get a 404 when deleting a non existing topic
+            System.out.println(" Cleaning up QUEUE " + topicName + " - not found, ignoring");
+          }
           return new PulsarQueue(topicName);
         }
       case "MY_TOPIC":

--- a/tck-executor/start_pulsar.sh
+++ b/tck-executor/start_pulsar.sh
@@ -2,8 +2,7 @@
 
 set -x -e
 
-# waiting for Apache Pulsar 2.10.1, in the meantime we use Luna Streaming 2.10.0.x
-IMAGENAME=${PULSAR_IMAGE_NAME:-datastax/lunastreaming:2.10_1.6}
+IMAGENAME=${PULSAR_IMAGE_NAME:-apachepulsar/pulsar:3.0.0}
 
 HERE=$(dirname $0)
 HERE=$(realpath "$HERE")


### PR DESCRIPTION
Summary:
- require JDK17 to build the project, because the server side Pulsar code requires it
- CI: use JDK17 for the tests
- CI: use JDK8 to run the TCK Executor (otherwise the TCK fails, and this is great because we are guaranteeing that it is compatible with JDK8) 
- change the way we use reflection to modify the "modifiers" in order to make tests run on JDK17
- update the code to bootstrap the BK cluster to work with BK 4.16.x
- fix Javadocs according to the errors reported by JDK17 javadoc

Note:
This patch disables the trick on the PriorityQueue, because in recent Pulsar versions we use a specific implementation of BlockingQueue and we cannot inject anymore a PriorityBlockingQueue
