### PR TITLE
Added null checks to fix NPEs uncovered during CTS testing

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -262,7 +262,11 @@ public abstract class PulsarMessage implements Message {
    */
   @Override
   public void setJMSCorrelationID(String correlationID) throws JMSException {
-    this.correlationId = correlationID.getBytes(StandardCharsets.UTF_8);
+    if (correlationID != null) {
+      this.correlationId = correlationID.getBytes(StandardCharsets.UTF_8);
+    } else {
+      this.correlationId = null;
+    }
   }
 
   /**
@@ -1095,7 +1099,9 @@ public abstract class PulsarMessage implements Message {
       return;
     }
     try {
-      consumer.acknowledge(receivedPulsarMessage, this, pulsarConsumer);
+      if (consumer != null) {
+        consumer.acknowledge(receivedPulsarMessage, this, pulsarConsumer);
+      }
     } catch (Exception err) {
       throw Utils.handleException(err);
     }


### PR DESCRIPTION
Found two separate locations in which an internal variable is referenced before checking to see is it is null or not. Both of these missing checks resulted in NullPointerExceptions during the CMS testing.