### PR TITLE
Allow PulsarQueueBrowser to handle PulsarTemporaryQueue as well

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -1441,7 +1441,7 @@ public class PulsarConnectionFactory
   }
 
   public List<Reader<?>> createReadersForBrowser(
-      PulsarQueue destination, ConsumerConfiguration overrideConsumerConfiguration)
+      PulsarDestination destination, ConsumerConfiguration overrideConsumerConfiguration)
       throws JMSException {
 
     if (destination.isRegExp()) {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarQueueBrowser.java
@@ -37,7 +37,7 @@ final class PulsarQueueBrowser implements QueueBrowser {
   private static final int BROWSER_READ_TIMEOUT = 1000;
 
   private final PulsarSession session;
-  private final PulsarQueue queue;
+  private final Queue queue;
   private final String subscriptionName;
   private final List<Reader<?>> readers;
   private final SelectorSupport selectorSupport;
@@ -49,16 +49,18 @@ final class PulsarQueueBrowser implements QueueBrowser {
     session.checkNotClosed();
     this.session = session;
     this.useServerSideFiltering = session.getFactory().isUseServerSideFiltering();
-    this.queue = (PulsarQueue) queue;
+    this.queue = queue;
     this.readers =
         session
             .getFactory()
-            .createReadersForBrowser(this.queue, session.getOverrideConsumerConfiguration());
+            .createReadersForBrowser(
+                (PulsarDestination) this.queue, session.getOverrideConsumerConfiguration());
     log.info("created {} readers for {}", readers.size(), this.queue);
     // we are reading messages and it is always safe to apply selectors
     // on the client side
     this.selectorSupport = SelectorSupport.build(selector, true);
-    this.subscriptionName = session.getFactory().getQueueSubscriptionName(this.queue);
+    this.subscriptionName =
+        session.getFactory().getQueueSubscriptionName((PulsarDestination) this.queue);
   }
 
   /**


### PR DESCRIPTION
The PulsarQueueBrowser cast all incoming Queue's to PulsarQueue, which causes a ClassCastException to be thrown when a PulsarTemporaryQueue instance (which implements the Queue interface) is passed in to the constructor. 

This PR removes the casting, which was unnecessary, and uses methods of the base class PulsarDestination instead of PulsarQueue within the constructor call itself.  