### PR TITLE
Set property type for String properties

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -1009,7 +1009,7 @@ public abstract class PulsarMessage implements Message {
   public void setStringProperty(String name, String value) throws JMSException {
     checkWritableProperty(name);
     properties.put(name, value);
-    // not type, not needed
+    properties.put(propertyType(name), "string");
   }
 
   /**

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/messages/PulsarMessagePropertiesTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/messages/PulsarMessagePropertiesTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms.messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.jms.JMSException;
+import org.junit.jupiter.api.Test;
+
+public class PulsarMessagePropertiesTest {
+
+  Boolean[] BOOLEANS = {Boolean.TRUE, Boolean.FALSE};
+  Byte[] BYTES = {Byte.MIN_VALUE, Byte.MAX_VALUE};
+  Short[] SHORTS = {Short.MIN_VALUE, Short.MAX_VALUE};
+  Integer[] INTS = {Integer.MIN_VALUE, Integer.MAX_VALUE};
+  Long[] LONGS = {Long.MIN_VALUE, Long.MAX_VALUE};
+  Float[] FLOATS = {Float.MIN_VALUE, Float.MAX_VALUE, Float.NaN};
+  Double[] DOUBLES = {Double.MIN_VALUE, Double.MAX_VALUE, Double.NaN};
+  String[] STRINGS = {"a", "b", "aaa", "bbb", "A", "B"};
+  Object[][] ALL_VALUES = {BOOLEANS, BYTES, SHORTS, INTS, LONGS, FLOATS, DOUBLES, STRINGS};
+
+  @Test
+  public final void testObjectPropertyTypes() throws JMSException {
+    PulsarSimpleMessage message = new PulsarSimpleMessage();
+    final String name = "test";
+
+    for (int i = 0; i < ALL_VALUES.length; ++i) {
+      Object[] values = ALL_VALUES[i];
+      for (int j = 0; j < values.length; ++j) {
+        Object value = values[j];
+        message.setObjectProperty(name, value);
+
+        // verify that the type is the same as that set
+        assertEquals(value.getClass(), message.getObjectProperty(name).getClass());
+
+        // test that set/get values are equal
+        if (value instanceof Float && ((Float) value).isNaN()) {
+          assertTrue(((Float) message.getObjectProperty(name)).isNaN());
+        } else if (value instanceof Double && ((Double) value).isNaN()) {
+          assertTrue(((Double) message.getObjectProperty(name)).isNaN());
+        } else {
+          assertEquals(value, message.getObjectProperty(name));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added logic to set the property type when setting an Object property to a String value. For some reason, Strings were the only type that this property wasn't explicitly set for, which I believe as due to the incorrect assumption that when deserializing the object the "default" type is String.

While that approach works for properties that are always and forever only set to strings, it DOES NOT work when the same property name has been previously set to a different type, e.g. Integer. In that case, the old property type is still applied, which results in a runtime exception.

I have added a unit test to demonstrate this. It uses a single message property named "name" and sets it to multiple values of different types. It will fail on the String properties without the patch in this PR.