### PR TITLE
Configure QueueBrowser's pulsar reader with subscription name

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -1546,6 +1546,7 @@ public class PulsarConnectionFactory
               .readerName("jms-queue-browser-" + UUID.randomUUID())
               .startMessageId(seekMessageId)
               .startMessageIdInclusive()
+              .subscriptionName(queueSubscriptionName)
               .topic(fullQualifiedTopicName);
       Reader<?> newReader = builder.create();
       readers.add(newReader);


### PR DESCRIPTION
`QueueBrowser` connect to Pulsar using a `Reader`. A reader looks like a normal consumer from the pulsar protocol perspective. It is associated with a subscription name, which is later used by the authorization framework to determine if the client's `role` has permission to perform the action on the subscription, even though the subscription is not technically used. Therefore, we need to make sure we configure the subscription name. This functionality won't really matter until we complete https://github.com/datastax/pulsar/pull/246 or some similar PR, so no tests are added. Given that we already use the `queueSubscriptionName` on an earlier line `getPulsarAdmin().topics().peekMessages(fullQualifiedTopicName, queueSubscriptionName, 1);`, there is little to no chance this will cause any issues.