### PR TITLE
Emulated transactions: defer writes to commit

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -1334,6 +1334,10 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
         });
   }
 
+  protected void rollbackEmulatedTransaction() {
+    uncommittedMessages = null;
+  }
+
   protected void commitEmulatedTransaction() throws JMSException {
     if (uncommittedMessages != null) {
       List<CompletableFuture<?>> callbacks = new ArrayList<>();

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -1229,6 +1229,10 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
                 }
                 uncommittedMessages.add(new PreparedMessage(typedMessageBuilder, pulsarMessage));
                 session.registerProducerWithTransaction(this);
+                if (defaultDeliveryDelay > 0) {
+                  typedMessageBuilder.deliverAfter(defaultDeliveryDelay, TimeUnit.MILLISECONDS);
+                }
+                return null;
               }
             } else {
               typedMessageBuilder = producer.newMessage();
@@ -1317,6 +1321,9 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
             } else {
               // emulated transactions
               typedMessageBuilder = producer.newMessage();
+              if (defaultDeliveryDelay > 0) {
+                typedMessageBuilder.deliverAfter(defaultDeliveryDelay, TimeUnit.MILLISECONDS);
+              }
               if (uncommittedMessages == null) {
                 uncommittedMessages = new ArrayList<>();
               }
@@ -1327,6 +1334,9 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
             }
           } else {
             typedMessageBuilder = producer.newMessage();
+          }
+          if (defaultDeliveryDelay > 0) {
+            typedMessageBuilder.deliverAfter(defaultDeliveryDelay, TimeUnit.MILLISECONDS);
           }
           pulsarMessage.sendAsync(
               typedMessageBuilder, finalCompletionListener, session, this, disableMessageTimestamp);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -25,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -136,6 +137,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
   private final AtomicLong transactionStickyKey = new AtomicLong();
   private final ConsumersInterceptor consumerInterceptor = new ConsumersInterceptor();
   private final List<Message> connectionConsumerTasks = new ArrayList<>();
+  private final Set<PulsarMessageProducer> producersWithTransactions;
 
   private final AtomicReference<Runnable> connectionConsumerPostProcessingTask =
       new AtomicReference<>();
@@ -148,6 +150,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
     if (sessionMode == SESSION_TRANSACTED && !connection.getFactory().isEnableTransaction()) {
       if (connection.getFactory().isEmulateTransactions()) {
         emulateTransactions = true;
+        producersWithTransactions = new HashSet<>();
       } else {
         throw new JMSException(
             "Please enable transactions on PulsarConnectionFactory with enableTransaction=true, you can configure "
@@ -155,6 +158,7 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
       }
     } else {
       emulateTransactions = false;
+      producersWithTransactions = null;
     }
     this.jms20 = false;
     this.connection = connection;
@@ -249,6 +253,12 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
 
   PulsarConnectionFactory getFactory() {
     return connection.getFactory();
+  }
+
+  protected void registerProducerWithTransaction(PulsarMessageProducer producer) {
+    synchronized (producersWithTransactions) {
+      producersWithTransactions.add(producer);
+    }
   }
 
   Producer<byte[]> getProducerForDestination(Destination destination) throws JMSException {
@@ -572,6 +582,13 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
               msg.acknowledgeInternal();
             }
             unackedMessages.clear();
+          }
+          // we are postponing to this moment the writes
+          synchronized (producersWithTransactions) {
+            for (PulsarMessageProducer producer : producersWithTransactions) {
+              producer.commitEmulatedTransaction();
+            }
+            producersWithTransactions.clear();
           }
         }
         if (transaction != null) {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -665,9 +665,11 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
     synchronized (unackedMessages) {
       unackedMessages.clear();
     }
-    synchronized (producersWithTransactions) {
-      producersWithTransactions.forEach(PulsarMessageProducer::rollbackEmulatedTransaction);
-      producersWithTransactions.clear();
+    if (emulateTransactions) {
+      synchronized (producersWithTransactions) {
+        producersWithTransactions.forEach(PulsarMessageProducer::rollbackEmulatedTransaction);
+        producersWithTransactions.clear();
+      }
     }
     if (transaction != null) {
       Utils.get(transaction.abort());

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarSession.java
@@ -665,6 +665,10 @@ public class PulsarSession implements Session, QueueSession, TopicSession {
     synchronized (unackedMessages) {
       unackedMessages.clear();
     }
+    synchronized (producersWithTransactions) {
+      producersWithTransactions.forEach(PulsarMessageProducer::rollbackEmulatedTransaction);
+      producersWithTransactions.clear();
+    }
     if (transaction != null) {
       Utils.get(transaction.abort());
     }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -981,13 +981,11 @@ public class TransactionsTest {
                 TextMessage textMsg = producerSession.createTextMessage("foo");
                 producer.send(textMsg);
               }
+              producerSession.commit();
 
               // message is "visible" as producer transaction is not committed but
               // we are only emulating transactions and so the message is sent immediately
               Awaitility.await().until(() -> !received.isEmpty());
-
-              // commit producer (useless in this case)
-              producerSession.commit();
 
               received.clear();
 


### PR DESCRIPTION
Modifications:
- when enabling the jms.emulateTransactions mode writes are deferred to the commit()
- the writes are executed in parallel using Pulsar producer async send in order to get the best performance

Motivation:
Many users use Transactions only in order to get better performance and they are not really interested in the semantics. This happened because in some systems when you enable transaction there is some kind of buffering, like the one implemented in this  PR.


Notes:
- as for message ID we use the id returned by the broker, with this mode you don't get the message id after sending the message
- in case of errors during the write, we log the error, but the application receives only a generic error during commit()