### PR TITLE
deps: update activemq-version to fix CVE-2023-46604

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <jms.version>2.0.3</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
     <pulsar.version>3.2.2</pulsar.version>
-    <activemq.version>5.16.1</activemq.version>
+    <activemq.version>5.16.7</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
This PR fixes [CVE-2023-46604](https://nvd.nist.gov/vuln/detail/CVE-2023-46604)
By upgrading activemq-version to [5.16.7](https://activemq.apache.org/news/cve-2023-46604)