### PR TITLE
Publish Filters: do not block the pulsar-io thread and other performance improvements

### DIFF
--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/MessageMetadataCache.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/MessageMetadataCache.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms.selectors;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+class MessageMetadataCache {
+  final Map<String, Object> properties = new HashMap<>();
+
+  Object getProperty(String key, Function<String, Object> compute) {
+    return properties.computeIfAbsent(key, compute);
+  }
+}

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -128,10 +128,10 @@
             <configuration>
               <target>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <mkdir dir="${project.build.outputDirectory}/interceptors" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/interceptors/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <mkdir dir="${project.build.outputDirectory}/interceptors"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/interceptors/jms-filter.nar"/>
               </target>
             </configuration>
           </execution>

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersBaseMemoryCacheTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersBaseMemoryCacheTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JMSPublishFiltersBaseMemoryCacheTest extends JMSPublishFiltersBase {
+
+  @RegisterExtension
+  static PulsarContainerExtension pulsarContainer =
+      new PulsarContainerExtension()
+          .withEnv("PULSAR_PREFIX_transactionCoordinatorEnabled", "true")
+          .withEnv("PULSAR_PREFIX_brokerInterceptorsDirectory", "/pulsar/interceptors")
+          .withEnv("PULSAR_PREFIX_brokerInterceptors", "jms-publish-filters")
+          .withEnv("PULSAR_PREFIX_jmsApplyFiltersOnPublish", "true")
+          .withEnv("PULSAR_PREFIX_jmsFiltersOnPublishMaxMemoryMB", "110")
+          .withEnv("PULSAR_PREFIX_jmsFiltersOnPublishThreads", "10")
+          .withLogContainerOutput(true);
+
+  @Override
+  PulsarContainerExtension getPulsarContainer() {
+    return pulsarContainer;
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersBaseMemoryNoCacheTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersBaseMemoryNoCacheTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JMSPublishFiltersBaseMemoryNoCacheTest extends JMSPublishFiltersBase {
+
+  @RegisterExtension
+  static PulsarContainerExtension pulsarContainer =
+      new PulsarContainerExtension()
+          .withEnv("PULSAR_PREFIX_transactionCoordinatorEnabled", "true")
+          .withEnv("PULSAR_PREFIX_brokerInterceptorsDirectory", "/pulsar/interceptors")
+          .withEnv("PULSAR_PREFIX_brokerInterceptors", "jms-publish-filters")
+          .withEnv("PULSAR_PREFIX_jmsApplyFiltersOnPublish", "true")
+          .withEnv("PULSAR_PREFIX_jmsFiltersOnPublishMaxMemoryMB", "0") // cache disabled
+          .withEnv("PULSAR_PREFIX_jmsFiltersOnPublishThreads", "10")
+          .withLogContainerOutput(true);
+
+  @Override
+  PulsarContainerExtension getPulsarContainer() {
+    return pulsarContainer;
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersTest.java
@@ -50,6 +50,8 @@ public class JMSPublishFiltersTest {
           .withEnv("PULSAR_PREFIX_brokerInterceptorsDirectory", "/pulsar/interceptors")
           .withEnv("PULSAR_PREFIX_brokerInterceptors", "jms-publish-filters")
           .withEnv("PULSAR_PREFIX_jmsApplyFiltersOnPublish", "true")
+          .withEnv("PULSAR_PREFIX_jmsFiltersOnPublishMaxMemoryMB", "1")
+          .withEnv("PULSAR_PREFIX_jmsFiltersOnPublishThreads", "1")
           .withLogContainerOutput(true);
 
   private Map<String, Object> buildProperties() {


### PR DESCRIPTION
Summary:
This is a big rework about the execution of the JMSPublishFilters.

It is solving these issues:
- the processing of the filters for a given subscription was pinned to a thread, so you couldn't use fully all the cores
- acknowledging the messages 1 at a time is too slow, because it takes a writeLock and also when it is time to flush to the BK ledger the serialization and compression of the individuallyDeletesMessages list takes much time
- in case of reaching the max amount of memory the procedure was blocking the Netty event loop, staling the rest of the broker
- previosly each subscription was processed independently, wasting resources for MessageMetadata serialization (both memory and CPU cycles)

How does it work:

1. The processing of the filters now happens in a dedicated thread pool, and each processing is not pinned to a subscription, this way a broker with few partitions can still use all of the available cores.

2. The calls to Subscription.acknowledgeMessage(listOfPositions) are grouped and also executed in parallel, this reduces the contention on the cursor and reduces the amount of processing needed to handle the cursor

3. The procedure that executes the filter is not blocking for the "ack" to be persisted, but it executes only the filtering code

4. The execution of the filter now fully processes a message against all the interested Subscriptions, this has 2 benefits: no waste of resources to deserialize the MessageMetadata once per Subscription, and also we can "cache" the String representation of the properties.
In fact if the same messages has to be processed by tens of Subscription the broker can now parse only once the PropertiesList and convert it to a Map, with faster access time. This is a big deal when the filters has to access many property or access the same property across  multiple selectors

5. In order to not block the Netty eventloop when the memory is ehausted the filter operation is still enqued but without retaining a copy of the MessageMetadata. At processing time if the metadata are missing then the Message is read from storage (BookKeeper). This read leverages the Broker cache (and BK reads deduplication), that is very likely to contain the entry if there are consumers connected.


This patch adds new metrics to monitor the behavior of the JMSPublishFilters:
- `pulsar_jmsfilter_ack_time_onpublish`: this is the time spent to process acks by the JMSPublishFilters (it is an histogram)
- `pulsar_jmsfilter_overall_processing_time_onpublish`: this is the whole time for a message to be fully processed (doing a rate on pulsar_jmsfilter_overall_processing_time_onpublish_count allows you to compute the processing rate of the filter
- `pulsar_jmsfilter_processing_pending_acks`: number of acks not yet processed
- `pulsar_jmsfilter_entries_read_from_ledger`: number of reads from storage requested by the JMSPublishFilters

This patch adds new configuration entries in broker.conf:
- `jmsFiltersOnPublishThreads`: number of thread to process filters on JMSPublishFilters (default is num cores * 4, the number is greated than num cores because there are potentially blocking IO opeations when reading from storage)
- `jmsFiltersOnPublishMaxMemoryMB`: now you can set it to zero in order to disable the additional cache, the default is now 256 (it used to be 128)