### PR TITLE
JMSPublishFilters save memory allocations and CPU cycles by caching null values for non-existant properties

### DIFF
--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -736,7 +736,7 @@ public class JMSFilter implements EntryFilter {
     // we pre-compute the type in order to avoid to scan the list to fine the type
     String type = SYSTEM_PROPERTIES_TYPES.get(name);
     if (type == null) {
-      type = cacheProperties.get(propertyType(name));
+      type = propertyType(name);
     }
     String value = cacheProperties.get(name);
     return getObjectProperty(value, type);

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -566,8 +566,7 @@ public class JMSFilter implements EntryFilter {
 
     private Object getProperty(String name) {
       if (messageMetadataCache != null) {
-        return messageMetadataCache.getProperty(
-            name, n -> JMSFilter.getProperty(propertiesCount, propertiesList, n));
+        return messageMetadataCache.getProperty(name);
       }
       return JMSFilter.getProperty(propertiesCount, propertiesList, name);
     }
@@ -726,6 +725,20 @@ public class JMSFilter implements EntryFilter {
         break;
       }
     }
+    return getObjectProperty(value, type);
+  }
+
+  static Object getProperty(Map<String, String> cacheProperties, String name) {
+    if (cacheProperties.isEmpty()) {
+      return null;
+    }
+    // we don't write the type for system fields
+    // we pre-compute the type in order to avoid to scan the list to fine the type
+    String type = SYSTEM_PROPERTIES_TYPES.get(name);
+    if (type == null) {
+      type = cacheProperties.get(propertyType(name));
+    }
+    String value = cacheProperties.get(name);
     return getObjectProperty(value, type);
   }
 

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSPublishFilters.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSPublishFilters.java
@@ -411,7 +411,7 @@ public class JMSPublishFilters implements BrokerInterceptor {
       // if we have more than one subscription we can save a lot of resources by caching the
       // properties
       MessageMetadataCache messageMetadataCache =
-          subscriptions.size() > 1 ? new MessageMetadataCache() : null;
+          subscriptions.size() > 1 ? new MessageMetadataCache(messageMetadata) : null;
       for (Subscription subscription : subscriptions) {
         if (closed.get()) {
           // the broker is shutting down, we cannot process the entries

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/MessageMetadataCache.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/MessageMetadataCache.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 
-class MessageMetadataCache {
+final class MessageMetadataCache {
   final Map<String, String> rawProperties = new HashMap<>();
   final Map<String, Object> properties = new HashMap<>();
   private static final Object CACHED_NULL = new Object();
@@ -34,18 +34,18 @@ class MessageMetadataCache {
   }
 
   Object getProperty(String key) {
-    Object cached = properties.get(key);
-    if (cached == CACHED_NULL) {
-      return null;
-    }
-    if (cached != null) {
-      return cached;
-    }
-    Object result = JMSFilter.getProperty(rawProperties, key);
+    Object result = properties.get(key);
     if (result == null) {
-      properties.put(key, CACHED_NULL);
-    } else {
-      properties.put(key, result);
+      result = JMSFilter.getProperty(rawProperties, key);
+      if (result == null) {
+        properties.put(key, CACHED_NULL);
+      } else {
+        properties.put(key, result);
+      }
+      return result;
+    }
+    if (result == CACHED_NULL) {
+      return null;
     }
     return result;
   }


### PR DESCRIPTION
There are two places in which we use Map.computeIfAbsent in the JMSPublishFilters code path.
The problem with computeIfAbsent is that null values are not cached and so the broker ends up in scanning the whole list of properties in case of a selector that refers to a properties that is not set on the message.

Motification:
- cache a dummy sentinel value in order to not redo the search every time
- eagerly pre-cache as a Map all the properties of the Message in case the Message is to be processed by more than 1 Subcription