### PR TITLE
JMSPublishFilters: fix metadata cache and introduce new threadpool for acks

### DIFF
--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSFilter.java
@@ -736,7 +736,7 @@ public class JMSFilter implements EntryFilter {
     // we pre-compute the type in order to avoid to scan the list to fine the type
     String type = SYSTEM_PROPERTIES_TYPES.get(name);
     if (type == null) {
-      type = propertyType(name);
+      type = cacheProperties.get(propertyType(name));
     }
     String value = cacheProperties.get(name);
     return getObjectProperty(value, type);

--- a/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSPublishFilters.java
+++ b/pulsar-jms-filters/src/main/java/com/datastax/oss/pulsar/jms/selectors/JMSPublishFilters.java
@@ -592,7 +592,12 @@ public class JMSPublishFilters implements BrokerInterceptor {
     log.info("Broker is shutting down. Disabling JMSPublishFilters interceptor");
     closed.set(true);
     filter.close();
-    executor.shutdown();
+    if (executor != null) {
+      executor.shutdown();
+    }
+    if (drainAckQueueExecutor != null) {
+      drainAckQueueExecutor.shutdown();
+    }
   }
 
   @Override

--- a/pulsar-jms-filters/src/test/java/com/datastax/oss/pulsar/jms/selectors/MessageMetadataCacheTest.java
+++ b/pulsar-jms-filters/src/test/java/com/datastax/oss/pulsar/jms/selectors/MessageMetadataCacheTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms.selectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+
+class MessageMetadataCacheTest {
+
+  @org.junit.jupiter.api.Test
+  void testGetProperty() {
+    MessageMetadata metadata = new MessageMetadata();
+    metadata.addProperty().setKey("foo").setValue("bar");
+    metadata.addProperty().setKey("i_jsmtype").setValue("int");
+    metadata.addProperty().setKey("i").setValue("5");
+    MessageMetadataCache cache = new MessageMetadataCache(metadata);
+    assertNull(cache.getProperty("key"));
+    assertEquals("bar", cache.getProperty("foo"));
+    assertEquals(5, cache.getProperty("i"));
+  }
+}


### PR DESCRIPTION
Modifications:
- introduce a dedicated threadpool for handling acks in order to prevent a deadlock in which all the worker threads are trying to put into the acks queue, but no thread is able to drain
- fix a regression in handling non-string properties