### PR TITLE
[improvement] Do not throw error for Temporary Topic/Queue creation and deletion without admin privileges

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
@@ -912,11 +912,7 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
     checkNotClosed();
     String name =
         "persistent://" + factory.getSystemNamespace() + "/jms-temp-queue-" + UUID.randomUUID();
-    try {
-      factory.getPulsarAdmin().topics().createNonPartitionedTopic(name);
-    } catch (Exception err) {
-      throw Utils.handleException(err);
-    }
+    createNonPartitionedTopic(name);
     PulsarTemporaryQueue res = new PulsarTemporaryQueue(name, session);
     temporaryDestinations.add(res);
     return res;
@@ -926,11 +922,7 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
     checkNotClosed();
     String name =
         "persistent://" + factory.getSystemNamespace() + "/jms-temp-topic-" + UUID.randomUUID();
-    try {
-      factory.getPulsarAdmin().topics().createNonPartitionedTopic(name);
-    } catch (Exception err) {
-      throw Utils.handleException(err);
-    }
+    createNonPartitionedTopic(name);
     PulsarTemporaryTopic res = new PulsarTemporaryTopic(name, session);
     temporaryDestinations.add(res);
     return res;
@@ -994,6 +986,14 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
         new PulsarConnectionConsumer(dispatcherSession, consumer, sessionPool, maxMessages);
     connectionConsumer.start();
     return connectionConsumer;
+  }
+
+  private void createNonPartitionedTopic(String name) {
+    try {
+      factory.getPulsarAdmin().topics().createNonPartitionedTopic(name);
+    } catch (Exception err) {
+      log.warn("Skipping creation of nonPartitionedTopic {}", name, err);
+    }
   }
 
   void refreshServerSideSelectors() {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -148,6 +148,7 @@ public class PulsarConnectionFactory
   private transient SubscriptionType topicSharedSubscriptionType = SubscriptionType.Shared;
   private transient long waitForServerStartupTimeout = 60000;
   private transient boolean usePulsarAdmin = true;
+  private transient boolean allowTemporaryTopicWithoutAdmin = true;
   private transient boolean precreateQueueSubscription = true;
   private transient int precreateQueueSubscriptionConsumerQueueSize = 0;
   private transient boolean initialized;
@@ -329,6 +330,11 @@ public class PulsarConnectionFactory
 
       this.usePulsarAdmin =
           Boolean.parseBoolean(getAndRemoveString("jms.usePulsarAdmin", "true", configurationCopy));
+
+      this.allowTemporaryTopicWithoutAdmin =
+          Boolean.parseBoolean(
+              getAndRemoveString(
+                  "jms.allowTemporaryTopicWithoutAdmin", "false", configurationCopy));
 
       this.precreateQueueSubscription =
           Boolean.parseBoolean(
@@ -1724,6 +1730,10 @@ public class PulsarConnectionFactory
 
   public boolean isAcknowledgeRejectedMessages() {
     return acknowledgeRejectedMessages;
+  }
+
+  public boolean isAllowTemporaryTopicWithoutAdmin() {
+    return allowTemporaryTopicWithoutAdmin;
   }
 
   public synchronized boolean isClosed() {

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -148,7 +148,7 @@ public class PulsarConnectionFactory
   private transient SubscriptionType topicSharedSubscriptionType = SubscriptionType.Shared;
   private transient long waitForServerStartupTimeout = 60000;
   private transient boolean usePulsarAdmin = true;
-  private transient boolean allowTemporaryTopicWithoutAdmin = true;
+  private transient boolean allowTemporaryTopicWithoutAdmin = false;
   private transient boolean precreateQueueSubscription = true;
   private transient int precreateQueueSubscriptionConsumerQueueSize = 0;
   private transient boolean initialized;

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTemporaryDestination.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTemporaryDestination.java
@@ -52,8 +52,7 @@ abstract class PulsarTemporaryDestination extends PulsarDestination {
         log.warn("Cannot delete a temporary destination {}", this, e);
         return;
       }
-      TopicStats stats =
-          pulsarAdmin.topics().getStats(fullQualifiedTopicName);
+      TopicStats stats = pulsarAdmin.topics().getStats(fullQualifiedTopicName);
       log.info("Stats {}", stats);
 
       int numConsumers =

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTemporaryDestination.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTemporaryDestination.java
@@ -18,6 +18,7 @@ package com.datastax.oss.pulsar.jms;
 import javax.jms.InvalidDestinationException;
 import javax.jms.JMSException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.TopicStats;
 
@@ -44,8 +45,15 @@ abstract class PulsarTemporaryDestination extends PulsarDestination {
       log.info("Deleting {}", this);
       String topicName = getInternalTopicName();
       String fullQualifiedTopicName = session.getFactory().applySystemNamespace(topicName);
+      PulsarAdmin pulsarAdmin;
+      try {
+        pulsarAdmin = session.getFactory().getPulsarAdmin();
+      } catch (Exception e) {
+        log.warn("Cannot delete a temporary destination {}", this, e);
+        return;
+      }
       TopicStats stats =
-          session.getFactory().getPulsarAdmin().topics().getStats(fullQualifiedTopicName);
+          pulsarAdmin.topics().getStats(fullQualifiedTopicName);
       log.info("Stats {}", stats);
 
       int numConsumers =

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TemporaryDestinationsNonAdminTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TemporaryDestinationsNonAdminTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
+import java.util.Map;
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.IllegalStateException;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Slf4j
+public class TemporaryDestinationsNonAdminTest {
+
+    @RegisterExtension
+    static PulsarContainerExtension pulsarContainer =
+            new PulsarContainerExtension()
+                    .withEnv("PULSAR_PREFIX_allowAutoTopicCreation", "true")
+                    .withEnv("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned")
+                    .withEnv("PULSAR_PREFIX_transactionCoordinatorEnabled", "false");
+
+    @Test
+    public void allowTemporaryTopicWithoutAdminTest() throws Exception {
+        Map<String, Object> properties = getJmsProperties();
+        properties.put("jms.allowTemporaryTopicWithoutAdmin", "true");
+        useTemporaryDestinationNonAdminTest(properties, false);
+    }
+
+    @Test
+    public void forbidTemporaryTopicWithoutAdminTest() throws Exception {
+        Map<String, Object> properties = getJmsProperties();
+        useTemporaryDestinationNonAdminTest(properties, true);
+    }
+
+    @NotNull
+    private static Map<String, Object> getJmsProperties() {
+        Map<String, Object> properties = pulsarContainer.buildJMSConnectionProperties();
+        properties.put("jms.forceDeleteTemporaryDestinations", "true");
+        properties.put("jms.usePulsarAdmin", "false");
+        return properties;
+    }
+
+    private void useTemporaryDestinationNonAdminTest(Map<String, Object> properties, boolean expectAdminErrors)
+            throws Exception {
+
+        try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties)) {
+            try (Connection connection = factory.createConnection()) {
+                connection.start();
+                try (Session session = connection.createSession()) {
+                    if (expectAdminErrors) {
+                        assertThrows(IllegalStateException.class, session::createTemporaryTopic);
+                        return;
+                    }
+                    Destination clientAddress = session.createTemporaryTopic();
+                    testProducerAndConsumer(session, clientAddress);
+                }
+            }
+        }
+    }
+
+    private static void testProducerAndConsumer(Session session, Destination clientAddress)
+            throws JMSException {
+        try (MessageProducer producerClient = session.createProducer(clientAddress)) {
+            // subscribe on the temporary queue
+            try (MessageConsumer consumerClient = session.createConsumer(clientAddress)) {
+
+                String testMessage = "message";
+                // produce a message
+                producerClient.send(session.createTextMessage(testMessage));
+
+                // on the consumer receive the message
+                Message theResponse = consumerClient.receive();
+                assertEquals(testMessage, theResponse.getBody(String.class));
+            }
+        }
+    }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TemporaryDestinationsNonAdminTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TemporaryDestinationsNonAdminTest.java
@@ -71,7 +71,7 @@ public class TemporaryDestinationsNonAdminTest {
                 connection.start();
                 try (Session session = connection.createSession()) {
                     if (expectAdminErrors) {
-                        assertThrows(IllegalStateException.class, session::createTemporaryTopic);
+                        assertThrows(JMSException.class, session::createTemporaryTopic);
                         return;
                     }
                     Destination clientAddress = session.createTemporaryTopic();


### PR DESCRIPTION
- Parent Ticket is [STREAM-503](https://datastax.jira.com/browse/STREAM-503)
- When `jms.usePulsarAdmin=false`, do not throw error for temporary topic/queue creation or deletion.
- Relying on pulsar `autoTopicCreation` for non-partitioned topics and auto delete functionality for inactive topics.
- Added `jms.allowTemporaryTopicWithoutAdmin` for making the changes configurable. When `true`, no errors will be thrown and temporary topics/queues wouldn't need admin access. When `false`, errors will be thrown and temporary topic/queue creation is forbidden.

[STREAM-503]: https://datastax.jira.com/browse/STREAM-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ