### PR TITLE
Upgrade apache pulsar to 3.3.2 to fix CVE-2024-47561 in avro

### DIFF
--- a/.github/workflows/tck-client-side-filters.yaml
+++ b/.github/workflows/tck-client-side-filters.yaml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/tck-server-side-filters.yaml
+++ b/.github/workflows/tck-server-side-filters.yaml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <jms.version>3.0.0</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
-    <pulsar.version>3.2.2</pulsar.version>
+    <pulsar.version>3.3.2</pulsar.version>
     <activemq.version>6.0.0</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>


### PR DESCRIPTION
Upgraded Apache Pulsar dependency to version `3.3.2` to include Avro `1.11.4`, addressing [CVE-2024-47561](https://nvd.nist.gov/vuln/detail/cve-2024-47561) vulnerability in Avro 1.11.3.