### PR TITLE
Upgrade apache pulsar to 3.3.2 to fix CVE-2024-47561 in Avro (branch-6.0)

### DIFF
--- a/.github/workflows/tck-client-side-filters.yaml
+++ b/.github/workflows/tck-client-side-filters.yaml
@@ -32,7 +32,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/tck-server-side-filters.yaml
+++ b/.github/workflows/tck-server-side-filters.yaml
@@ -32,7 +32,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,5 +31,5 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build and test
-        run: mvn -B clean javadoc:javadoc verify
+        run: mvn -B clean javadoc:javadoc verify -DrerunFailingTestsCount=3
 

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.4</version>
+          <version>3.5.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.release>8</maven.compiler.release>
     <jms.version>2.0.3</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
-    <pulsar.version>3.2.2</pulsar.version>
+    <pulsar.version>3.3.2</pulsar.version>
     <activemq.version>5.16.7</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>


### PR DESCRIPTION
Upgraded Apache Pulsar dependency to version `3.3.2` to include Avro `1.11.4`, addressing [CVE-2024-47561](https://nvd.nist.gov/vuln/detail/cve-2024-47561) vulnerability in Avro 1.11.3 (pulsar-jms 6.x).