### PR TITLE
Upgrade apache pulsar to 3.3.2 to fix CVE-2024-47561 in Avro (branch-6.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,10 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
           </exclusion>
+            <exclusion>
+              <groupId>org.apache.avro</groupId>
+              <artifactId>avro-protobuf</artifactId>
+            </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -146,12 +150,6 @@
         <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-client-admin-original</artifactId>
         <version>${pulsar.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>
@@ -203,6 +201,11 @@
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
+        <version>1.11.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-protobuf</artifactId>
         <version>1.11.4</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,12 @@
         <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-client-original</artifactId>
         <version>${pulsar.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>
@@ -140,6 +146,12 @@
         <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-client-admin-original</artifactId>
         <version>${pulsar.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>
@@ -187,6 +199,11 @@
         <groupId>jakarta.jms</groupId>
         <artifactId>jakarta.jms-api</artifactId>
         <version>${jms.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>1.11.4</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -47,6 +47,16 @@
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client-original</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-protobuf</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
@@ -81,6 +91,16 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.11.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-protobuf</artifactId>
+      <version>1.11.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Upgraded Apache Pulsar dependency to version 3.3.2 to include Avro 1.11.4, addressing [CVE-2024-47561](https://nvd.nist.gov/vuln/detail/cve-2024-47561) vulnerability in Avro 1.11.3 (pulsar-jms 6.x).