### PR TITLE
Defer PulsarAdmin creation to solve SpringBoot initialization problems

### DIFF
--- a/pulsar-jms-cli/src/main/java/com/datastax/oss/pulsar/jms/cli/Main.java
+++ b/pulsar-jms-cli/src/main/java/com/datastax/oss/pulsar/jms/cli/Main.java
@@ -204,7 +204,7 @@ public class Main {
       PulsarConnectionFactory factory = getFactory();
       String topicName = factory.getPulsarTopicName(destination);
       log.info("JMS Destination {} maps to Pulsar Topic {}", destination, topicName);
-      PulsarAdmin pulsarAdmin = factory.getPulsarAdmin();
+      PulsarAdmin pulsarAdmin = factory.getPulsarAdmin().getPulsarAdmin();
       try {
         TopicStats stats = pulsarAdmin.topics().getStats(topicName);
         Map<String, ? extends SubscriptionStats> subscriptions = stats.getSubscriptions();
@@ -250,7 +250,7 @@ public class Main {
       PulsarConnectionFactory factory = getFactory();
       String topicName = factory.getPulsarTopicName(destination);
       log.info("JMS Destination {} maps to Pulsar Topic {}", destination, topicName);
-      PulsarAdmin pulsarAdmin = factory.getPulsarAdmin();
+      PulsarAdmin pulsarAdmin = factory.getPulsarAdmin().getPulsarAdmin();
       TopicStats stats = pulsarAdmin.topics().getStats(topicName);
       Map<String, ? extends SubscriptionStats> subscriptions = stats.getSubscriptions();
       if (subscriptions.isEmpty()) {

--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -103,8 +103,8 @@
             <configuration>
               <target>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </target>
             </configuration>
           </execution>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -135,10 +135,10 @@
             <configuration>
               <target>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <mkdir dir="${project.build.outputDirectory}/interceptors" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/interceptors/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <mkdir dir="${project.build.outputDirectory}/interceptors"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/interceptors/jms-filter.nar"/>
               </target>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarAdminWrapper.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarAdminWrapper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
+import org.apache.pulsar.common.policies.data.TopicStats;
+
+public interface PulsarAdminWrapper {
+
+  void close();
+
+  void createSubscription(
+      String fullQualifiedTopicName, String subscriptionName, MessageId earliest)
+      throws PulsarAdminException;
+
+  Map<String, String> getSubscriptionProperties(
+      String fullQualifiedTopicName, String subscriptionName) throws PulsarAdminException;
+
+  PartitionedTopicMetadata getPartitionedTopicMetadata(String fullQualifiedTopicName)
+      throws PulsarAdminException;
+
+  List<Message<byte[]>> peekMessages(
+      String fullQualifiedTopicName, String queueSubscriptionName, int i)
+      throws PulsarAdminException;
+
+  void deleteSubscription(String fullQualifiedTopicName, String name, boolean b)
+      throws PulsarAdminException;
+
+  List<String> getTopicList(String systemNamespace) throws PulsarAdminException;
+
+  List<String> getSubscriptions(String topic) throws PulsarAdminException;
+
+  <T> T getPulsarAdmin();
+
+  void createNonPartitionedTopic(String name) throws PulsarAdminException;
+
+  List<String> getPartitionedTopicList(String systemNamespace) throws PulsarAdminException;
+
+  TopicStats getStats(String fullQualifiedTopicName) throws PulsarAdminException;
+
+  void deletePartitionedTopic(
+      String fullQualifiedTopicName, boolean forceDeleteTemporaryDestinations)
+      throws PulsarAdminException;
+
+  void deleteTopic(String fullQualifiedTopicName, boolean forceDeleteTemporaryDestinations)
+      throws PulsarAdminException;
+
+  void createPartitionedTopic(String topicName, int i) throws PulsarAdminException;
+
+  PartitionedTopicStats getPartitionedTopicStats(String topicName, boolean b)
+      throws PulsarAdminException;
+}

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnection.java
@@ -990,7 +990,7 @@ public class PulsarConnection implements Connection, QueueConnection, TopicConne
 
   private void createPulsarTemporaryTopic(String name) throws JMSException {
     try {
-      factory.getPulsarAdmin().topics().createNonPartitionedTopic(name);
+      factory.getPulsarAdmin().createNonPartitionedTopic(name);
     } catch (IllegalStateException err) {
       if (!factory.isAllowTemporaryTopicWithoutAdmin()) {
         throw Utils.handleException(err);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSAdminImpl.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarJMSAdminImpl.java
@@ -109,7 +109,7 @@ class PulsarJMSAdminImpl implements JMSAdmin {
 
   private JMSDestinationMetadata describeDestination(PulsarDestination destination)
       throws JMSException {
-    PulsarAdmin pulsarAdmin = factory.ensurePulsarAdmin();
+    PulsarAdmin pulsarAdmin = factory.ensurePulsarAdmin().getPulsarAdmin();
     String pulsarTopic = factory.getPulsarTopicName(destination);
     String queueSubscription;
     if (destination.isQueue()) {
@@ -335,7 +335,8 @@ class PulsarJMSAdminImpl implements JMSAdmin {
         properties.put("jms.selector", selector);
       }
       String topicName = factory.getPulsarTopicName(dest);
-      Topics topics = factory.ensurePulsarAdmin().topics();
+      PulsarAdmin pulsarAdmin = factory.ensurePulsarAdmin().getPulsarAdmin();
+      Topics topics = pulsarAdmin.topics();
       topics.createSubscription(
           topicName,
           subscriptionName,
@@ -358,7 +359,8 @@ class PulsarJMSAdminImpl implements JMSAdmin {
           destination, d -> !dest.isVirtualDestination(), "Cannot create a VirtualDestination");
 
       String topicName = factory.getPulsarTopicName(dest);
-      Topics topics = factory.ensurePulsarAdmin().topics();
+      PulsarAdmin pulsarAdmin = factory.ensurePulsarAdmin().getPulsarAdmin();
+      Topics topics = pulsarAdmin.topics();
       boolean exists = false;
       try {
         PartitionedTopicMetadata partitionedTopicMetadata =
@@ -409,7 +411,8 @@ class PulsarJMSAdminImpl implements JMSAdmin {
           destination, d -> !dest.isVirtualDestination(), "Cannot create a VirtualDestination");
 
       String topicName = factory.getPulsarTopicName(dest);
-      Topics topics = factory.ensurePulsarAdmin().topics();
+      PulsarAdmin pulsarAdmin = factory.ensurePulsarAdmin().getPulsarAdmin();
+      Topics topics = pulsarAdmin.topics();
       try {
         PartitionedTopicMetadata partitionedTopicMetadata =
             topics.getPartitionedTopicMetadata(topicName);
@@ -454,7 +457,8 @@ class PulsarJMSAdminImpl implements JMSAdmin {
       boolean enableFilters, String selector, String topicName, String subscriptionName)
       throws JMSException, PulsarAdminException {
     validateSelector(enableFilters, selector);
-    Topics topics = factory.ensurePulsarAdmin().topics();
+    PulsarAdmin pulsarAdmin = factory.ensurePulsarAdmin().getPulsarAdmin();
+    Topics topics = pulsarAdmin.topics();
     Map<String, String> currentProperties = new HashMap<>();
     try {
       currentProperties = topics.getSubscriptionProperties(topicName, subscriptionName);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/RealPulsarAdminWrapperFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/RealPulsarAdminWrapperFactory.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import java.util.List;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
+import org.apache.pulsar.common.policies.data.TopicStats;
+
+public class RealPulsarAdminWrapperFactory {
+
+  public static PulsarAdminWrapper createPulsarAdmin(
+      String webServiceUrl,
+      boolean tlsAllowInsecureConnection,
+      boolean tlsEnableHostnameVerification,
+      String tlsTrustCertsFilePath,
+      boolean useKeyStoreTls,
+      String tlsTrustStoreType,
+      String tlsTrustStorePath,
+      String tlsTrustStorePassword,
+      Authentication authentication)
+      throws PulsarClientException {
+
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(PulsarAdmin.class.getClassLoader());
+      return new RealPulsarAdminWrapper(
+          webServiceUrl,
+          tlsAllowInsecureConnection,
+          tlsEnableHostnameVerification,
+          tlsTrustCertsFilePath,
+          useKeyStoreTls,
+          tlsTrustStoreType,
+          tlsTrustStorePath,
+          tlsTrustStorePassword,
+          authentication);
+    } finally {
+      Thread.currentThread().setContextClassLoader(classLoader);
+    }
+  }
+
+  private static class RealPulsarAdminWrapper implements PulsarAdminWrapper {
+    private final PulsarAdmin pulsarAdmin;
+
+    private RealPulsarAdminWrapper(
+        String webServiceUrl,
+        boolean tlsAllowInsecureConnection,
+        boolean tlsEnableHostnameVerification,
+        String tlsTrustCertsFilePath,
+        boolean useKeyStoreTls,
+        String tlsTrustStoreType,
+        String tlsTrustStorePath,
+        String tlsTrustStorePassword,
+        Authentication authentication)
+        throws PulsarClientException {
+      this.pulsarAdmin =
+          PulsarAdmin.builder()
+              .serviceHttpUrl(webServiceUrl)
+              .allowTlsInsecureConnection(tlsAllowInsecureConnection)
+              .enableTlsHostnameVerification(tlsEnableHostnameVerification)
+              .tlsTrustCertsFilePath(tlsTrustCertsFilePath)
+              .useKeyStoreTls(useKeyStoreTls)
+              .tlsTrustStoreType(tlsTrustStoreType)
+              .tlsTrustStorePath(tlsTrustStorePath)
+              .tlsTrustStorePassword(tlsTrustStorePassword)
+              .authentication(authentication)
+              .build();
+    }
+
+    @Override
+    public void close() {
+      pulsarAdmin.close();
+    }
+
+    @Override
+    public void createSubscription(
+        String fullQualifiedTopicName,
+        String subscriptionName,
+        org.apache.pulsar.client.api.MessageId earliest)
+        throws PulsarAdminException {
+      pulsarAdmin.topics().createSubscription(fullQualifiedTopicName, subscriptionName, earliest);
+    }
+
+    @Override
+    public java.util.Map<String, String> getSubscriptionProperties(
+        String fullQualifiedTopicName, String subscriptionName) throws PulsarAdminException {
+      return pulsarAdmin
+          .topics()
+          .getSubscriptionProperties(fullQualifiedTopicName, subscriptionName);
+    }
+
+    @Override
+    public org.apache.pulsar.common.partition.PartitionedTopicMetadata getPartitionedTopicMetadata(
+        String fullQualifiedTopicName) throws PulsarAdminException {
+      return pulsarAdmin.topics().getPartitionedTopicMetadata(fullQualifiedTopicName);
+    }
+
+    @Override
+    public java.util.List<org.apache.pulsar.client.api.Message<byte[]>> peekMessages(
+        String fullQualifiedTopicName, String queueSubscriptionName, int i)
+        throws PulsarAdminException {
+      return pulsarAdmin.topics().peekMessages(fullQualifiedTopicName, queueSubscriptionName, i);
+    }
+
+    @Override
+    public void deleteSubscription(String fullQualifiedTopicName, String name, boolean b)
+        throws PulsarAdminException {
+      pulsarAdmin.topics().deleteSubscription(fullQualifiedTopicName, name, b);
+    }
+
+    @Override
+    public java.util.List<String> getTopicList(String systemNamespace) throws PulsarAdminException {
+      return pulsarAdmin.topics().getList(systemNamespace);
+    }
+
+    @Override
+    public java.util.List<String> getSubscriptions(String topic) throws PulsarAdminException {
+      return pulsarAdmin.topics().getSubscriptions(topic);
+    }
+
+    @Override
+    public void createNonPartitionedTopic(String name) throws PulsarAdminException {
+      pulsarAdmin.topics().createNonPartitionedTopic(name);
+    }
+
+    @Override
+    public List<String> getPartitionedTopicList(String systemNamespace)
+        throws PulsarAdminException {
+      return pulsarAdmin.topics().getPartitionedTopicList(systemNamespace);
+    }
+
+    @Override
+    public TopicStats getStats(String fullQualifiedTopicName) throws PulsarAdminException {
+      return pulsarAdmin.topics().getStats(fullQualifiedTopicName);
+    }
+
+    @Override
+    public void deletePartitionedTopic(
+        String fullQualifiedTopicName, boolean forceDeleteTemporaryDestinations)
+        throws PulsarAdminException {
+      pulsarAdmin
+          .topics()
+          .deletePartitionedTopic(fullQualifiedTopicName, forceDeleteTemporaryDestinations);
+    }
+
+    @Override
+    public void deleteTopic(String fullQualifiedTopicName, boolean forceDeleteTemporaryDestinations)
+        throws PulsarAdminException {
+      pulsarAdmin.topics().delete(fullQualifiedTopicName, forceDeleteTemporaryDestinations);
+    }
+
+    @Override
+    public void createPartitionedTopic(String topicName, int i) throws PulsarAdminException {
+      pulsarAdmin.topics().createPartitionedTopic(topicName, i);
+    }
+
+    @Override
+    public PartitionedTopicStats getPartitionedTopicStats(String topicName, boolean b)
+        throws PulsarAdminException {
+      return pulsarAdmin.topics().getPartitionedStats(topicName, b);
+    }
+
+    public <T> T getPulsarAdmin() {
+      return (T) pulsarAdmin;
+    }
+  }
+}

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/BasicServerSideFilterTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/BasicServerSideFilterTest.java
@@ -32,9 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
@@ -183,11 +181,10 @@ public class BasicServerSideFilterTest {
 
           // PreconditionFailedException
 
-          PulsarAdmin original = factory.getPulsarAdmin();
-          PulsarAdmin mockPulsarAdmin = mock(PulsarAdmin.class);
-          Topics topics = mock(Topics.class);
+          PulsarAdminWrapper original = factory.getPulsarAdmin();
+          PulsarAdminWrapper mockPulsarAdmin = mock(PulsarAdminWrapper.class);
           AtomicBoolean done = new AtomicBoolean();
-          when(topics.getSubscriptionProperties(anyString(), anyString()))
+          when(mockPulsarAdmin.getSubscriptionProperties(anyString(), anyString()))
               .thenAnswer(
                   i -> {
                     done.set(true);
@@ -197,7 +194,6 @@ public class BasicServerSideFilterTest {
                     throw new PulsarAdminException.PreconditionFailedException(
                         new Exception(), "", 404);
                   });
-          when(mockPulsarAdmin.topics()).thenReturn(topics);
           Whitebox.setInternalState(factory, "pulsarAdmin", mockPulsarAdmin);
 
           try (PulsarMessageConsumer consumer1 =

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersBase.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSPublishFiltersBase.java
@@ -176,7 +176,7 @@ public abstract class JMSPublishFiltersBase {
       try (PulsarConnection connection = factory.createConnection()) {
         connection.start();
         try (PulsarSession session = connection.createSession(Session.AUTO_ACKNOWLEDGE); ) {
-          factory.getPulsarAdmin().topics().createPartitionedTopic(topicName, 20);
+          factory.getPulsarAdmin().createPartitionedTopic(topicName, 20);
 
           Queue destination = session.createQueue(topicName);
 
@@ -227,7 +227,7 @@ public abstract class JMSPublishFiltersBase {
                 .untilAsserted(
                     () -> {
                       PartitionedTopicStats partitionedInternalStats =
-                          factory.getPulsarAdmin().topics().getPartitionedStats(topicName, true);
+                          factory.getPulsarAdmin().getPartitionedTopicStats(topicName, true);
                       AtomicLong sum = new AtomicLong();
                       partitionedInternalStats
                           .getPartitions()

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TemporaryDestinationsNonAdminTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TemporaryDestinationsNonAdminTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
-import java.util.Map;
 import jakarta.jms.Connection;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
@@ -27,6 +26,7 @@ import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TransactionsTest.java
@@ -1224,7 +1224,7 @@ public class TransactionsTest {
         connection.start();
 
         // create a topic with 4 partitions
-        factory.getPulsarAdmin().topics().createPartitionedTopic(topicName, 4);
+        factory.getPulsarAdmin().createPartitionedTopic(topicName, 4);
 
         try (Session consumerSession = connection.createSession(); ) {
           Destination destination = consumerSession.createQueue(topicName);

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/VirtualDestinationsConsumerTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/VirtualDestinationsConsumerTest.java
@@ -87,9 +87,9 @@ public class VirtualDestinationsConsumerTest {
           for (int i = 0; i < 4; i++) {
             String topicName = "test-" + prefix + "-" + i;
             if (numPartitions > 0) {
-              factory.getPulsarAdmin().topics().createPartitionedTopic(topicName, numPartitions);
+              factory.getPulsarAdmin().createPartitionedTopic(topicName, numPartitions);
             } else {
-              factory.getPulsarAdmin().topics().createNonPartitionedTopic(topicName);
+              factory.getPulsarAdmin().createNonPartitionedTopic(topicName);
             }
             destinationsToWrite.add(session.createTopic(topicName));
           }
@@ -424,7 +424,7 @@ public class VirtualDestinationsConsumerTest {
           List<Topic> destinationsToWrite = new ArrayList<>();
           for (int i = 0; i < 4; i++) {
             String topicName = "test-" + prefix + "-" + nextDestinationId;
-            factory.getPulsarAdmin().topics().createNonPartitionedTopic(topicName);
+            factory.getPulsarAdmin().createNonPartitionedTopic(topicName);
             destinationsToWrite.add(session.createTopic(topicName));
             nextDestinationId = i + 1;
           }
@@ -459,7 +459,7 @@ public class VirtualDestinationsConsumerTest {
             // add a new topic matching the pattern
             // the new topic has server side filters on the jms-queue subscription
             String topicName = "test-" + prefix + "-" + nextDestinationId;
-            factory.getPulsarAdmin().topics().createNonPartitionedTopic(topicName);
+            factory.getPulsarAdmin().createNonPartitionedTopic(topicName);
             // await that the consumer session creates the subscription, then we update it
             Awaitility.await()
                 .untilAsserted(

--- a/tck-executor/src/main/java/com/datastax/oss/pulsar/jms/tests/JNDIInitialContextFactory.java
+++ b/tck-executor/src/main/java/com/datastax/oss/pulsar/jms/tests/JNDIInitialContextFactory.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.spi.InitialContextFactory;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 
 public class JNDIInitialContextFactory implements InitialContextFactory {
@@ -128,7 +129,8 @@ public class JNDIInitialContextFactory implements InitialContextFactory {
           PulsarConnectionFactory tmp = getAdminConnectionFactory();
           System.out.println(this.getClass() + " Cleaning up QUEUE " + topicName);
           try {
-            tmp.getPulsarAdmin().topics().delete(topicName, true, true);
+            PulsarAdmin pulsarAdmin = tmp.getPulsarAdmin().getPulsarAdmin();
+            pulsarAdmin.topics().delete(topicName, true, true);
           } catch (PulsarAdminException.NotFoundException ok) {
             // Since Pulsar 3.0 we get a 404 when deleting a non existing topic
             System.out.println(" Cleaning up QUEUE " + topicName + " - not found, ignoring");


### PR DESCRIPTION
Modifications:
- do not create PulsarAdmin if it is not disabled
- defer loading the PulsarAdmin class and enforce the context class loader

May fix #162 