### PR TITLE
Reverted pulsar version to 3.2.2 while fixing avro vulnerability

### DIFF
--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <!-- DataStax Apache Pulsar JMS Client -->
       <groupId>com.datastax.oss</groupId>
-      <artifactId>pulsar-jms-all</artifactId>
+      <artifactId>pulsar-jms</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <jms.version>3.0.0</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
-    <pulsar.version>3.3.2</pulsar.version>
+    <pulsar.version>3.2.2</pulsar.version>
     <activemq.version>6.0.0</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
@@ -130,6 +130,26 @@
         <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-client-original</artifactId>
         <version>${pulsar.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-protobuf</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>1.11.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-protobuf</artifactId>
+        <version>1.11.4</version>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -54,6 +54,26 @@
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client-original</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-protobuf</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.11.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-protobuf</artifactId>
+      <version>1.11.4</version>
     </dependency>
     <dependency>
       <groupId>${pulsar.groupId}</groupId>


### PR DESCRIPTION
To address the AVRO vulnerability, [PR#165](https://github.com/datastax/pulsar-jms/pull/165) was merged into the master branch, and [PR#161](https://github.com/datastax/pulsar-jms/pull/161) was merged into the branch-6.0. The changes on master branch upgraded the Pulsar version to 3.3.2, which includes the FeatureNotSupportedException class, a class that is not present in earlier versions.

However, in the spring-example application, there are dependency discrepancies. While pulsar-client-original is upgraded to 3.3.2, some of its nested modules are still on version 3.2.3, which lacks the FeatureNotSupportedException class.

Additionally, with the changes introduced in [PR#163](https://github.com/datastax/pulsar-jms/pull/163), which disables PulsarAdmin creation, another error is triggered—ClassNotFoundException. This occurs because the FeatureNotSupportedException class is missing in Pulsar 3.2.3.

Rolling back to an older version of Pulsar & fixing avro vulnerability just like [PR#161](https://github.com/datastax/pulsar-jms/pull/161) resolves the issue. 
Once the migration from javax to Jakarta in Pulsar is complete, this problem should no longer occur.