### PR TITLE
Upgrade apache Commons Compress: from 1.3 through 1.25.0 fix CVE-2024-25710  (branch-6.0.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <surefire.version>3.1.0</surefire.version>
     <jackson.version>2.14.2</jackson.version>
     <gson.version>2.8.9</gson.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.26.0</commons-compress.version>
     <awaitility.version>4.0.3</awaitility.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
Loop with Unreachable Exit Condition ('Infinite Loop') vulnerability in Apache Commons Compress. This issue affects Apache Commons Compress: from 1.3 through 1.25.0. CVE-2024-25710