### PR TITLE
extend the PulsarConnectionFactory to using temporary producers

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -1243,6 +1243,7 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
             pulsarMessage.send(typedMessageBuilder, disableMessageTimestamp, session);
           } finally {
             session.unblockTransactionOperations();
+            session.getFactory().closeTempProducer(producer);
           }
           if (message != pulsarMessage) {
             applyBackMessageProperties(message, pulsarMessage);
@@ -1269,77 +1270,82 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
     }
     session.executeCriticalOperation(
         () -> {
-          Producer<byte[]> producer = session.getProducerForDestination(defaultDestination);
-          message.setJMSDestination(defaultDestination);
-          PulsarMessage pulsarMessage = prepareMessageForSend(message);
-          CompletionListener endActivityCompletionListener =
-              new CompletionListener() {
-                @Override
-                public void onCompletion(Message message) {
-                  try {
-                    completionListener.onCompletion(message);
-                  } finally {
-                    session.unblockTransactionOperations();
-                  }
-                }
-
-                @Override
-                public void onException(Message message, Exception exception) {
-                  try {
-                    completionListener.onException(message, exception);
-                  } finally {
-                    session.unblockTransactionOperations();
-                  }
-                }
-              };
-          CompletionListener finalCompletionListener = endActivityCompletionListener;
-          if (pulsarMessage != message) {
-            finalCompletionListener =
+          Producer<byte[]> producer = null;
+          try {
+            producer = session.getProducerForDestination(defaultDestination);
+            message.setJMSDestination(defaultDestination);
+            PulsarMessage pulsarMessage = prepareMessageForSend(message);
+            CompletionListener endActivityCompletionListener =
                 new CompletionListener() {
                   @Override
-                  public void onCompletion(Message completedMessage) {
-                    // we have to pass the original message to the called
-                    applyBackMessageProperties(message, pulsarMessage);
-                    endActivityCompletionListener.onCompletion(message);
+                  public void onCompletion(Message message) {
+                    try {
+                      completionListener.onCompletion(message);
+                    } finally {
+                      session.unblockTransactionOperations();
+                    }
                   }
 
                   @Override
-                  public void onException(Message completedMessage, Exception e) {
-                    // we have to pass the original message to the called
-                    applyBackMessageProperties(message, pulsarMessage);
-                    endActivityCompletionListener.onException(message, e);
+                  public void onException(Message message, Exception exception) {
+                    try {
+                      completionListener.onException(message, exception);
+                    } finally {
+                      session.unblockTransactionOperations();
+                    }
                   }
                 };
-          }
+            CompletionListener finalCompletionListener = endActivityCompletionListener;
+            if (pulsarMessage != message) {
+              finalCompletionListener =
+                  new CompletionListener() {
+                    @Override
+                    public void onCompletion(Message completedMessage) {
+                      // we have to pass the original message to the called
+                      applyBackMessageProperties(message, pulsarMessage);
+                      endActivityCompletionListener.onCompletion(message);
+                    }
 
-          session.blockTransactionOperations();
-          TypedMessageBuilder<byte[]> typedMessageBuilder;
-          if (session.getTransacted()) {
-            Transaction transaction = session.getTransaction();
-            if (transaction != null) {
-              typedMessageBuilder = producer.newMessage(transaction);
-            } else {
-              // emulated transactions
-              typedMessageBuilder = producer.newMessage();
-              if (defaultDeliveryDelay > 0) {
-                typedMessageBuilder.deliverAfter(defaultDeliveryDelay, TimeUnit.MILLISECONDS);
-              }
-              if (uncommittedMessages == null) {
-                uncommittedMessages = new ArrayList<>();
-              }
-              uncommittedMessages.add(new PreparedMessage(typedMessageBuilder, pulsarMessage));
-              session.registerProducerWithTransaction(this);
-              finalCompletionListener.onCompletion(pulsarMessage);
-              return null;
+                    @Override
+                    public void onException(Message completedMessage, Exception e) {
+                      // we have to pass the original message to the called
+                      applyBackMessageProperties(message, pulsarMessage);
+                      endActivityCompletionListener.onException(message, e);
+                    }
+                  };
             }
-          } else {
-            typedMessageBuilder = producer.newMessage();
+
+            session.blockTransactionOperations();
+            TypedMessageBuilder<byte[]> typedMessageBuilder;
+            if (session.getTransacted()) {
+              Transaction transaction = session.getTransaction();
+              if (transaction != null) {
+                typedMessageBuilder = producer.newMessage(transaction);
+              } else {
+                // emulated transactions
+                typedMessageBuilder = producer.newMessage();
+                if (defaultDeliveryDelay > 0) {
+                  typedMessageBuilder.deliverAfter(defaultDeliveryDelay, TimeUnit.MILLISECONDS);
+                }
+                if (uncommittedMessages == null) {
+                  uncommittedMessages = new ArrayList<>();
+                }
+                uncommittedMessages.add(new PreparedMessage(typedMessageBuilder, pulsarMessage));
+                session.registerProducerWithTransaction(this);
+                finalCompletionListener.onCompletion(pulsarMessage);
+                return null;
+              }
+            } else {
+              typedMessageBuilder = producer.newMessage();
+            }
+            if (defaultDeliveryDelay > 0) {
+              typedMessageBuilder.deliverAfter(defaultDeliveryDelay, TimeUnit.MILLISECONDS);
+            }
+            pulsarMessage.sendAsync(
+                typedMessageBuilder, finalCompletionListener, session, this, disableMessageTimestamp);
+          } finally {
+            session.getFactory().closeTempProducer(producer);
           }
-          if (defaultDeliveryDelay > 0) {
-            typedMessageBuilder.deliverAfter(defaultDeliveryDelay, TimeUnit.MILLISECONDS);
-          }
-          pulsarMessage.sendAsync(
-              typedMessageBuilder, finalCompletionListener, session, this, disableMessageTimestamp);
           return null;
         });
   }


### PR DESCRIPTION
- add configuration property "useTempProducer" -> enables the temporary producer feature, distinguishing between temporary and non-temporary producers. Temporary producers are closed and removed immediately after their first use (i.e., after sending a message). This property is optional, with a default value of "false"
- add configuration property "tempTopicNamePrefix" ->  when "tempProducerConfig.useTempProducer" is enabled, you can explicitly specify the sequence in the topic/queue name. This property is optional, with a default value of "jms-temp-queue".