### PR TITLE
[STREAM-555] Fix for Release plugin issue with the newly introduced submodule

### DIFF
--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -330,6 +330,20 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -25,8 +25,10 @@
   </parent>
   <groupId>${pulsar.groupId}</groupId>
   <artifactId>pulsar-client-jms</artifactId>
-  <version>${pulsar.version}</version>
   <name>Pulsar Client Java</name>
+  <properties>
+    <maven.release.skip>true</maven.release.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${pulsar.groupId}</groupId>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client-jms</artifactId>
-      <version>${pulsar.version}</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
### Motivation
With the changes introduced in #167 , the maven release plugin was having the following issue.
> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project pulsar-jms-parent: The version could not be updated: ${pulsar.version} -> [Help 1]

This is due to the maven release plugin limitations as it expects a literal version number.

Jira Link: https://datastax.jira.com/browse/STREAM-555

### Changes
- Added property to skip Maven release for `pulsar-client-jms` and configured Maven deploy plugin to skip deployment for the same.
- Updated dependency version in `pulsar-jms-all/pom.xml` to use `${project.version}` instead of `${pulsar.version}` for `pulsar-client-jms` and removed version tag for `pulsar-client-jms`.