### PR TITLE
Cherry Pick PR for 6.x.x releases with necessary changes from master

### DIFF
--- a/activemq-filters/pom.xml
+++ b/activemq-filters/pom.xml
@@ -44,9 +44,24 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.fusesource.hawtbuf</groupId>
+      <artifactId>hawtbuf</artifactId>
+      <version>${hawtbuf.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <additionalOptions>
+            <additionalOption>-Xdoclint:none</additionalOption>
+          </additionalOptions>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>

--- a/examples/payara-micro/pom.xml
+++ b/examples/payara-micro/pom.xml
@@ -117,10 +117,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/examples/payara-micro/pom.xml
+++ b/examples/payara-micro/pom.xml
@@ -109,20 +109,6 @@
           <contextRoot>/</contextRoot>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -24,7 +24,6 @@
     <version>6.0.4-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
-  <groupId>com.example</groupId>
   <artifactId>pulsar-jms-spring-example</artifactId>
   <name>Pulsar JMS Spring Example</name>
   <description>Demo project for Spring Boot and Pulsar JMS</description>
@@ -81,10 +80,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -72,20 +72,6 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>2.4.5</version>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@ limitations under the License.]]></inlineHeader>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.7</version>
+          <version>1.6.13</version>
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -418,7 +418,7 @@ limitations under the License.]]></inlineHeader>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>2.8.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
@@ -430,18 +430,6 @@ limitations under the License.]]></inlineHeader>
             <goals>deploy</goals>
             <arguments>-DskipTests</arguments>
             <tagNameFormat>@{project.version}</tagNameFormat>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.sonatype.central</groupId>
-          <artifactId>central-publishing-maven-plugin</artifactId>
-          <version>0.7.0</version>
-          <extensions>true</extensions>
-          <configuration>
-            <publishingServerId>ossrh</publishingServerId>
-            <checksums>all</checksums>
-            <autoPublish>false</autoPublish>
-            <skipPublishing>false</skipPublishing>
           </configuration>
         </plugin>
       </plugins>
@@ -495,6 +483,74 @@ limitations under the License.]]></inlineHeader>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <sourcepath>src/main/java</sourcepath>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <checksums>all</checksums>
+          <autoPublish>false</autoPublish>
+          <skipPublishing>false</skipPublishing>
+          <waitUntil>validated</waitUntil>
+          <deploymentName>DEPLOYMENT-pulsar-jms-${project.version}</deploymentName>
+          <excludeArtifacts>
+            <excludeArtifact>pulsar-client-jms</excludeArtifact>
+            <excludeArtifact>pulsar-jms-resource-adapter-tests</excludeArtifact>
+            <excludeArtifact>pulsar-jms-integration-tests</excludeArtifact>
+            <excludeArtifact>pulsar-jms-cli</excludeArtifact>
+            <excludeArtifact>pulsar-jms-admin-ext</excludeArtifact>
+            <excludeArtifact>payara-example</excludeArtifact>
+            <excludeArtifact>pulsar-jms-spring-example</excludeArtifact>
+            <excludeArtifact>tck-executor</excludeArtifact>
+          </excludeArtifacts>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+          <arguments>-DskipTests</arguments>
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <licenses>
@@ -527,36 +583,6 @@ limitations under the License.]]></inlineHeader>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
-            <configuration>
-              <sourcepath>src/main/java</sourcepath>
-              <excludedocfilessubdir>com/datastax/oss/pulsar/jms/cli/**</excludedocfilessubdir>
-            </configuration>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
             <executions>
               <execution>
@@ -572,18 +598,18 @@ limitations under the License.]]></inlineHeader>
       </build>
     </profile>
   </profiles>
-  <distributionManagement>
-    <!-- releases go to Maven central -->
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-  <!-- to use Luna Straaming -->
+  <!--  <distributionManagement>-->
+  <!--    &lt;!&ndash; releases go to Maven central &ndash;&gt;-->
+  <!--    <snapshotRepository>-->
+  <!--      <id>ossrh</id>-->
+  <!--      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>-->
+  <!--    </snapshotRepository>-->
+  <!--    <repository>-->
+  <!--      <id>ossrh</id>-->
+  <!--      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
+  <!--    </repository>-->
+  <!--  </distributionManagement>-->
+  <!-- to use Luna Streaming -->
   <repositories>
     <repository>
       <id>DataStax Public repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -559,9 +559,13 @@ limitations under the License.]]></inlineHeader>
   </profiles>
   <distributionManagement>
     <!-- releases go to Maven central -->
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
   <!-- to use Luna Straaming -->

--- a/pom.xml
+++ b/pom.xml
@@ -472,15 +472,15 @@ limitations under the License.]]></inlineHeader>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
       </plugin>
-       <plugin>
-          <groupId>org.sonatype.central</groupId>
-          <artifactId>central-publishing-maven-plugin</artifactId>
-          <version>0.7.0</version>
-          <extensions>true</extensions>
-          <configuration>
-            <publishingServerId>ossrh</publishingServerId>
-          </configuration>
-        </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>ossrh</publishingServerId>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,11 @@
         <version>${snakeyaml.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>32.1.2-jre</version>
+      </dependency>
+      <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
         <version>${testcontainers.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -433,18 +433,13 @@ limitations under the License.]]></inlineHeader>
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.13</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
           <extensions>true</extensions>
           <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-            <!-- autoReleaseAfterClose=false means manually inspect and release artifacts in staging repo
-            can use mvn nexus-staging:release
-            or mvn nexus-staging:drop
-            -->
-            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            <publishingServerId>central</publishingServerId>
+            <checksums>all</checksums>
+            <autoPublish>false</autoPublish>
           </configuration>
         </plugin>
       </plugins>
@@ -586,17 +581,17 @@ limitations under the License.]]></inlineHeader>
       </build>
     </profile>
   </profiles>
-  <distributionManagement>
-    <!-- releases go to Maven central -->
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
+<!--  <distributionManagement>-->
+<!--    &lt;!&ndash; releases go to Maven central &ndash;&gt;-->
+<!--    <snapshotRepository>-->
+<!--      <id>ossrh</id>-->
+<!--      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>-->
+<!--    </snapshotRepository>-->
+<!--    <repository>-->
+<!--      <id>ossrh</id>-->
+<!--      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
+<!--    </repository>-->
+<!--  </distributionManagement>-->
   <!-- to use Luna Straaming -->
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
   </organization>
   <modules>
     <module>activemq-filters</module>
+    <module>pulsar-client-shaded</module>
     <module>pulsar-jms-filters</module>
     <module>pulsar-jms-admin-api</module>
     <module>pulsar-jms</module>
@@ -56,6 +57,9 @@
     <jms.version>2.0.3</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
     <pulsar.version>3.2.2</pulsar.version>
+    <asynchttpclient.version>2.12.1</asynchttpclient.version>
+    <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
+    <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
     <activemq.version>5.16.7</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
@@ -128,6 +132,36 @@
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>
+        <artifactId>pulsar-client-api</artifactId>
+        <version>${pulsar.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-protobuf</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>${pulsar.groupId}</groupId>
+        <artifactId>pulsar-client-messagecrypto-bc</artifactId>
+        <version>${pulsar.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-protobuf</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>${pulsar.groupId}</groupId>
         <artifactId>pulsar-client-original</artifactId>
         <version>${pulsar.version}</version>
         <exclusions>
@@ -140,6 +174,16 @@
             <artifactId>avro-protobuf</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>1.11.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-protobuf</artifactId>
+        <version>1.11.4</version>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>
@@ -197,16 +241,6 @@
         <groupId>jakarta.jms</groupId>
         <artifactId>jakarta.jms-api</artifactId>
         <version>${jms.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro</artifactId>
-        <version>1.11.4</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro-protobuf</artifactId>
-        <version>1.11.4</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -435,11 +435,13 @@ limitations under the License.]]></inlineHeader>
         <plugin>
           <groupId>org.sonatype.central</groupId>
           <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.7.0</version>
           <extensions>true</extensions>
           <configuration>
-            <publishingServerId>central</publishingServerId>
+            <publishingServerId>ossrh</publishingServerId>
             <checksums>all</checksums>
             <autoPublish>false</autoPublish>
+            <skipPublishing>false</skipPublishing>
           </configuration>
         </plugin>
       </plugins>
@@ -492,17 +494,6 @@ limitations under the License.]]></inlineHeader>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.7.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <publishingServerId>ossrh</publishingServerId>
-          <autoPublish>true</autoPublish>
-          <skipPublishing>false</skipPublishing>
-        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -581,17 +572,17 @@ limitations under the License.]]></inlineHeader>
       </build>
     </profile>
   </profiles>
-<!--  <distributionManagement>-->
-<!--    &lt;!&ndash; releases go to Maven central &ndash;&gt;-->
-<!--    <snapshotRepository>-->
-<!--      <id>ossrh</id>-->
-<!--      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>-->
-<!--    </snapshotRepository>-->
-<!--    <repository>-->
-<!--      <id>ossrh</id>-->
-<!--      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
-<!--    </repository>-->
-<!--  </distributionManagement>-->
+  <distributionManagement>
+    <!-- releases go to Maven central -->
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
   <!-- to use Luna Straaming -->
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,8 @@ limitations under the License.]]></inlineHeader>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>ossrh</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <skipPublishing>false</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -472,18 +472,15 @@ limitations under the License.]]></inlineHeader>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-          <skipLocalStaging>true</skipLocalStaging>
-        </configuration>
-      </plugin>
+       <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.7.0</version>
+          <extensions>true</extensions>
+          <configuration>
+            <publishingServerId>ossrh</publishingServerId>
+          </configuration>
+        </plugin>
     </plugins>
   </build>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <activemq.version>5.16.7</activemq.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <junit.version>5.7.1</junit.version>
     <surefire.version>3.1.0</surefire.version>
     <jackson.version>2.14.2</jackson.version>
@@ -73,6 +73,7 @@
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <testcontainers.version>1.18.3</testcontainers.version>
+    <lombok.version>1.18.30</lombok.version>
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>--add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED
       <!--Mockito-->--add-opens java.base/java.io=ALL-UNNAMED
@@ -128,7 +129,8 @@
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.30</version>
+        <version>${lombok.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>${pulsar.groupId}</groupId>
@@ -301,6 +303,13 @@
           <configuration>
             <compilerArgs>-Xlint:unchecked</compilerArgs>
             <fork>false</fork>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>
@@ -518,6 +527,10 @@ limitations under the License.]]></inlineHeader>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.2.0</version>
+            <configuration>
+              <sourcepath>src/main/java</sourcepath>
+              <excludedocfilessubdir>com/datastax/oss/pulsar/jms/cli/**</excludedocfilessubdir>
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -425,9 +425,26 @@ limitations under the License.]]></inlineHeader>
           <version>2.5.3</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
+            <useReleaseProfile>false</useReleaseProfile>
             <releaseProfiles>release</releaseProfiles>
+            <goals>deploy</goals>
             <arguments>-DskipTests</arguments>
             <tagNameFormat>@{project.version}</tagNameFormat>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+            <!-- autoReleaseAfterClose=false means manually inspect and release artifacts in staging repo
+            can use mvn nexus-staging:release
+            or mvn nexus-staging:drop
+            -->
+            <autoReleaseAfterClose>false</autoReleaseAfterClose>
           </configuration>
         </plugin>
       </plugins>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>pulsar-jms-parent</artifactId>
     <groupId>com.datastax.oss</groupId>
-    <version>7.0.3-SNAPSHOT</version>
+    <version>6.0.4-SNAPSHOT</version>
   </parent>
   <groupId>${pulsar.groupId}</groupId>
   <artifactId>pulsar-client-jms</artifactId>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -25,8 +25,10 @@
   </parent>
   <groupId>${pulsar.groupId}</groupId>
   <artifactId>pulsar-client-jms</artifactId>
-  <version>${pulsar.version}</version>
   <name>Pulsar Client Java</name>
+  <properties>
+    <maven.release.skip>true</maven.release.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
@@ -327,6 +329,20 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -329,20 +329,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pulsar-jms-parent</artifactId>
+    <groupId>com.datastax.oss</groupId>
+    <version>7.0.3-SNAPSHOT</version>
+  </parent>
+  <groupId>${pulsar.groupId}</groupId>
+  <artifactId>pulsar-client-jms</artifactId>
+  <version>${pulsar.version}</version>
+  <name>Pulsar Client Java</name>
+  <dependencies>
+    <dependency>
+      <groupId>${pulsar.groupId}</groupId>
+      <artifactId>pulsar-client-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${pulsar.groupId}</groupId>
+      <artifactId>pulsar-client-original</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${pulsar.groupId}</groupId>
+      <artifactId>pulsar-client-messagecrypto-bc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-protobuf</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${pulsar.groupId}</groupId>
+                  <artifactId>pulsar-client-original</artifactId>
+                  <version>${pulsar.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/ProtobufSchema.class</includes>
+                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.asynchttpclient</groupId>
+                  <artifactId>async-http-client</artifactId>
+                  <version>${asynchttpclient.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>org/asynchttpclient/config/ahc-default.properties</includes>
+                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven.antrun.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>shade-ahc-properties</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- shade the AsyncHttpClient ahc-default.properties files -->
+                <replace token="org.asynchttpclient." value="org.apache.pulsar.shade.org.asynchttpclient." file="${project.build.directory}/classes/org/asynchttpclient/config/ahc-default.properties"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Shade all the dependencies to avoid conflicts -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <minimizeJar>false</minimizeJar>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.pulsar:pulsar-client-original</include>
+                  <include>org.apache.bookkeeper:*</include>
+                  <include>org.apache.commons:commons-lang3</include>
+                  <include>commons-codec:commons-codec</include>
+                  <include>commons-collections:commons-collections</include>
+                  <include>org.asynchttpclient:*</include>
+                  <include>io.netty:netty-codec-http</include>
+                  <include>io.netty:netty-transport-native-epoll</include>
+                  <include>org.reactivestreams:reactive-streams</include>
+                  <include>com.typesafe.netty:netty-reactive-streams</include>
+                  <include>org.javassist:javassist</include>
+                  <include>com.google.guava:*</include>
+                  <include>org.checkerframework:*</include>
+                  <include>com.google.code.findbugs:*</include>
+                  <include>com.google.errorprone:*</include>
+                  <include>com.google.j2objc:*</include>
+                  <include>com.google.code.gson:gson</include>
+                  <include>com.fasterxml.jackson.*:*</include>
+                  <include>io.netty:*</include>
+                  <include>io.netty.incubator:*</include>
+                  <include>io.perfmark:*</include>
+                  <include>org.eclipse.jetty:*</include>
+                  <include>com.yahoo.datasketches:*</include>
+                  <include>commons-*:*</include>
+                  <include>io.swagger:*</include>
+                  <include>io.airlift:*</include>
+                  <include>org.apache.pulsar:pulsar-common</include>
+                  <include>com.yahoo.datasketches:sketches-core</include>
+                  <include>org.objenesis:*</include>
+                  <include>org.yaml:snakeyaml</include>
+                  <include>org.apache.avro:*</include>
+                  <!-- Avro transitive dependencies-->
+                  <include>com.thoughtworks.paranamer:paranamer</include>
+                  <include>org.apache.commons:commons-compress</include>
+                  <include>org.tukaani:xz</include>
+                  <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->
+                  <include>org.apache.pulsar:pulsar-client-messagecrypto-bc</include>
+                </includes>
+                <excludes>
+                  <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+                </excludes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>org.apache.pulsar:pulsar-client-original</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                  <excludes>
+                    <!-- bouncycastle jars could not be shaded, or the signatures will be wrong-->
+                    <exclude>org/bouncycastle/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>org.asynchttpclient</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.asynchttpclient</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.airlift</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.io.airlift</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
+                  <excludes>
+                    <exclude>com.google.protobuf.*</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.fasterxml.jackson</shadedPattern>
+                  <excludes>
+                    <exclude>com.fasterxml.jackson.annotation.*</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.checkerframework</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.checkerframework</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.javax.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.swagger</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.io.swagger</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.pulsar.policies</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.policies</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.yahoo.datasketches</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.yahoo.datasketches</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.yahoo.sketches</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.yahoo.sketches</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.eclipse.jetty</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.eclipse</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.reactivestreams</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.reactivestreams</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.typesafe</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.typesafe</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.yahoo.memory</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.yahoo.memory</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.objenesis</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.objenesis</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.yaml</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.yaml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.avro</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.avro</shadedPattern>
+                  <excludes>
+                    <exclude>org.apache.avro.reflect.AvroAlias</exclude>
+                    <exclude>org.apache.avro.reflect.AvroDefault</exclude>
+                    <exclude>org.apache.avro.reflect.AvroEncode</exclude>
+                    <exclude>org.apache.avro.reflect.AvroIgnore</exclude>
+                    <exclude>org.apache.avro.reflect.AvroMeta</exclude>
+                    <exclude>org.apache.avro.reflect.AvroName</exclude>
+                    <exclude>org.apache.avro.reflect.AvroSchema</exclude>
+                    <exclude>org.apache.avro.reflect.Nullable</exclude>
+                    <exclude>org.apache.avro.reflect.Stringable</exclude>
+                    <exclude>org.apache.avro.reflect.Union</exclude>
+                  </excludes>
+                </relocation>
+                <!--Avro transitive dependencies-->
+                <relocation>
+                  <pattern>org.codehaus.jackson</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.codehaus.jackson</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.thoughtworks.paranamer</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.thoughtworks.paranamer</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.tukaani</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.tukaani</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.bookkeeper</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.bookkeeper</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- This plugin is used to run a script after the package phase in order to rename
+            libnetty_transport_native_epoll_x86_64.so from Netty into
+            liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so
+            to reflect the shade that is being applied.
+         -->
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <version>${exec-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>rename-epoll-library</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${project.parent.basedir}/src/${rename.netty.native.libs}</executable>
+              <arguments>
+                <argument>${project.artifactId}-${project.version}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -23,7 +23,6 @@
     <groupId>com.datastax.oss</groupId>
     <version>6.0.4-SNAPSHOT</version>
   </parent>
-  <groupId>${pulsar.groupId}</groupId>
   <artifactId>pulsar-client-jms</artifactId>
   <name>Pulsar Client Java</name>
   <properties>
@@ -338,10 +337,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/pulsar-client-shaded/src/main/java/com/datastax/oss/pulsar/jms/shaded/Dummy.java
+++ b/pulsar-client-shaded/src/main/java/com/datastax/oss/pulsar/jms/shaded/Dummy.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms.shaded;
+
+/** Dummy interface to generate source and doc jars and keep maven happy. */
+public interface Dummy {}

--- a/pulsar-jms-admin-ext/pom.xml
+++ b/pulsar-jms-admin-ext/pom.xml
@@ -82,20 +82,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-jms-admin-ext/pom.xml
+++ b/pulsar-jms-admin-ext/pom.xml
@@ -90,10 +90,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-jms</artifactId>
       <version>${pulsar.version}</version>
       <exclusions>
         <exclusion>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client-jms</artifactId>
-      <version>${pulsar.version}</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -82,7 +82,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${pulsar.groupId}</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-client-jms</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/pulsar-jms-cli/pom.xml
+++ b/pulsar-jms-cli/pom.xml
@@ -40,6 +40,10 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
     </dependency>
     <dependency>

--- a/pulsar-jms-cli/pom.xml
+++ b/pulsar-jms-cli/pom.xml
@@ -102,20 +102,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-jms-cli/pom.xml
+++ b/pulsar-jms-cli/pom.xml
@@ -106,10 +106,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/pulsar-jms-cli/src/main/java/com/datastax/oss/pulsar/jms/cli/Main.java
+++ b/pulsar-jms-cli/src/main/java/com/datastax/oss/pulsar/jms/cli/Main.java
@@ -51,8 +51,9 @@ import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
-@Slf4j
 public class Main {
+
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Main.class);
 
   public static void main(String... args) {
     try {

--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -78,20 +78,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>${maven.antrun.plugin.version}</version>
         <executions>

--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -103,8 +103,8 @@
             <configuration>
               <target>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </target>
             </configuration>
           </execution>

--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -84,10 +84,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
       <plugin>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -148,10 +148,10 @@
             <configuration>
               <target>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <mkdir dir="${project.build.outputDirectory}/interceptors" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/interceptors/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <mkdir dir="${project.build.outputDirectory}/interceptors"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/interceptors/jms-filter.nar"/>
               </target>
             </configuration>
           </execution>

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSMessageHeaderTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/JMSMessageHeaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.pulsar.jms;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -5,14 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import javax.jms.Destination;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
 import javax.jms.JMSProducer;
 import javax.jms.TextMessage;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -20,34 +35,34 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @Timeout(value = 1, unit = TimeUnit.MINUTES)
 public class JMSMessageHeaderTest {
 
-    @RegisterExtension
-    static PulsarContainerExtension pulsarContainer = new PulsarContainerExtension();
+  @RegisterExtension
+  static PulsarContainerExtension pulsarContainer = new PulsarContainerExtension();
 
-    @Test
-    public void sendMessageWithHeaderReceiveJMSContext() throws Exception {
+  @Test
+  public void sendMessageWithHeaderReceiveJMSContext() throws Exception {
 
-        Map<String, Object> properties = pulsarContainer.buildJMSConnectionProperties();
-        try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
-            try (JMSContext context = factory.createContext()) {
-                Destination destination =
-                        context.createQueue("persistent://public/default/test-" + UUID.randomUUID());
-                try (JMSConsumer consumer = context.createConsumer(destination)) {
-                    JMSProducer producer = context.createProducer();
-                    String message = "Hey JMS!";
-                    TextMessage expTextMessage = context.createTextMessage(message);
-                    expTextMessage.setJMSReplyTo(destination);
-                    expTextMessage.setJMSType("mytype");
-                    expTextMessage.setJMSCorrelationIDAsBytes(new byte[] {1, 2, 3});
-                    producer.send(destination, expTextMessage);
-                    TextMessage actTextMessage = (TextMessage) consumer.receive();
+    Map<String, Object> properties = pulsarContainer.buildJMSConnectionProperties();
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties); ) {
+      try (JMSContext context = factory.createContext()) {
+        Destination destination =
+            context.createQueue("persistent://public/default/test-" + UUID.randomUUID());
+        try (JMSConsumer consumer = context.createConsumer(destination)) {
+          JMSProducer producer = context.createProducer();
+          String message = "Hey JMS!";
+          TextMessage expTextMessage = context.createTextMessage(message);
+          expTextMessage.setJMSReplyTo(destination);
+          expTextMessage.setJMSType("mytype");
+          expTextMessage.setJMSCorrelationIDAsBytes(new byte[] {1, 2, 3});
+          producer.send(destination, expTextMessage);
+          TextMessage actTextMessage = (TextMessage) consumer.receive();
 
-                    assertNotNull(actTextMessage);
-                    assertEquals(expTextMessage.getText(), actTextMessage.getText());
-                    assertEquals(expTextMessage.getJMSReplyTo(), actTextMessage.getJMSReplyTo());
-                    assertEquals(expTextMessage.getJMSType(), actTextMessage.getJMSType());
-                    assertArrayEquals(new byte[] {1, 2, 3}, actTextMessage.getJMSCorrelationIDAsBytes());
-                }
-            }
+          assertNotNull(actTextMessage);
+          assertEquals(expTextMessage.getText(), actTextMessage.getText());
+          assertEquals(expTextMessage.getJMSReplyTo(), actTextMessage.getJMSReplyTo());
+          assertEquals(expTextMessage.getJMSType(), actTextMessage.getJMSType());
+          assertArrayEquals(new byte[] {1, 2, 3}, actTextMessage.getJMSCorrelationIDAsBytes());
         }
+      }
     }
+  }
 }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ProducerCacheTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ProducerCacheTest.java
@@ -18,12 +18,12 @@ package com.datastax.oss.pulsar.jms;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
-import jakarta.jms.Connection;
-import jakarta.jms.JMSException;
-import jakarta.jms.MessageProducer;
-import jakarta.jms.Session;
-import jakarta.jms.TemporaryQueue;
 import java.util.Map;
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.junit.jupiter.api.Test;

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ProducerCacheTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/ProducerCacheTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TemporaryQueue;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Slf4j
+public class ProducerCacheTest {
+
+  @RegisterExtension
+  static PulsarContainerExtension pulsarContainer = new PulsarContainerExtension();
+
+  /**
+   * Test for jms.maxNumOfProducers.
+   *
+   * <p>Sets the maximum number of producers to 1. When two producers are created (on different
+   * topics), the cache should evict the oldest entry so that only 1 producer remains in the cache.
+   * Broker stats should reflect the same.
+   */
+  @Test
+  public void testMaxNumOfProducers() throws JMSException {
+    Map<String, Object> properties = pulsarContainer.buildJMSConnectionProperties();
+    // Configure maximum number of producers to 1.
+    properties.put("jms.maxNumOfProducers", "1");
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties)) {
+      try (Connection connection = factory.createConnection()) {
+        connection.start();
+        try (Session session = connection.createSession()) {
+          // Create two temporary queues and corresponding producers.
+          TemporaryQueue queue1 = session.createTemporaryQueue();
+          MessageProducer producer1 = session.createProducer(queue1);
+          producer1.send(session.createTextMessage("foo-1"));
+
+          TemporaryQueue queue2 = session.createTemporaryQueue();
+          MessageProducer producer2 = session.createProducer(queue2);
+          producer2.send(session.createTextMessage("foo-2"));
+
+          // Assert that at most 1 producer is retained in the cache.
+          assertEquals(1, factory.getProducers().size(), "Cache should contain at most 1 producer");
+          // Assert with broker stats that the evicted producer is closed.
+          int totalBrokerProducers = fetchProducerCount(queue1) + fetchProducerCount(queue2);
+          assertEquals(1, totalBrokerProducers, "Total broker producers count should be 1");
+        } catch (PulsarAdminException e) {
+          throw Utils.handleException(e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Test for jms.producerAutoCloseTimeoutSec.
+   *
+   * <p>Sets the auto-close timeout to 1 second. After creating a producer and sending a message,
+   * waiting longer than the timeout should result in the producer being evicted from the cache, and
+   * the underlying producer closed (as verified via broker stats).
+   */
+  @Test
+  public void testProducerAutoCloseTimeout() throws JMSException, InterruptedException {
+    Map<String, Object> properties = pulsarContainer.buildJMSConnectionProperties();
+    // Set the auto-close timeout to 1 second.
+    properties.put("jms.producerAutoCloseTimeoutSec", "1");
+
+    try (PulsarConnectionFactory factory = new PulsarConnectionFactory(properties)) {
+      try (Connection connection = factory.createConnection()) {
+        connection.start();
+        try (Session session = connection.createSession()) {
+          TemporaryQueue tempQueue = session.createTemporaryQueue();
+          MessageProducer producer = session.createProducer(tempQueue);
+          producer.send(session.createTextMessage("foo-1"));
+
+          // Assert that the producer is registered.
+          assertEquals(1, factory.getProducers().size(), "Cache should contain 1 producer");
+          assertEquals(1, fetchProducerCount(tempQueue), "Broker should have 1 producer initially");
+
+          // Wait longer than the auto-close timeout to allow expiration.
+          Thread.sleep(2000);
+          // Trigger cache cleanup to remove the expired entry.
+          factory.getProducers().cleanUp();
+
+          // Now, the cache should be empty.
+          assertEquals(
+              0, factory.getProducers().size(), "Cache should be empty after auto-close timeout");
+          // Verify with broker stats that no producers exist.
+          assertEquals(
+              0,
+              fetchProducerCount(tempQueue),
+              "Broker should have 0 producers after auto-close timeout");
+        } catch (PulsarAdminException e) {
+          throw Utils.handleException(e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper method to fetch the number of producers for a given temporary queue from broker stats.
+   */
+  private static int fetchProducerCount(TemporaryQueue tempQueue)
+      throws PulsarAdminException, JMSException {
+    return pulsarContainer
+        .getAdmin()
+        .topics()
+        .getStats(tempQueue.getQueueName())
+        .getPublishers()
+        .size();
+  }
+}

--- a/resource-adapter-tests/pom.xml
+++ b/resource-adapter-tests/pom.xml
@@ -108,10 +108,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/resource-adapter-tests/pom.xml
+++ b/resource-adapter-tests/pom.xml
@@ -100,20 +100,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/rename-netty-native-libs.sh
+++ b/src/rename-netty-native-libs.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+ARTIFACT_ID=$1
+JAR_PATH="$PWD/target/$ARTIFACT_ID.jar"
+
+FILE_PREFIX='META-INF/native'
+
+FILES_TO_RENAME=(
+    'libnetty_transport_native_epoll_x86_64.so liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so'
+    'libnetty_tcnative_linux_x86_64.so liborg_apache_pulsar_shade_netty_tcnative_linux_x86_64.so'
+    'libnetty_resolver_dns_native_macos_aarch_64.jnilib liborg_apache_pulsar_shade_netty_resolver_dns_native_macos_aarch_64.jnilib'
+    'libnetty_resolver_dns_native_macos_x86_64.jnilib liborg_apache_pulsar_shade_netty_resolver_dns_native_macos_x86_64.jnilib'
+)
+
+echo "----- Renaming epoll lib in $JAR_PATH ------"
+TMP_DIR=`mktemp -d`
+CUR_DIR=$(pwd)
+cd ${TMP_DIR}
+# exclude `META-INF/LICENSE`
+unzip -q $JAR_PATH -x "META-INF/LICENSE"
+# include `META-INF/LICENSE` as LICENSE.netty.
+# This approach is to get around the issue that MacOS is not able to recognize the difference between `META-INF/LICENSE` and `META-INF/license/`.
+unzip -p $JAR_PATH META-INF/LICENSE > META-INF/LICENSE.netty
+cd ${CUR_DIR}
+
+pushd $TMP_DIR
+
+for line in "${FILES_TO_RENAME[@]}"; do
+    read -r -a A <<< "$line"
+    FROM=${A[0]}
+    TO=${A[1]}
+
+    if [ -f $FILE_PREFIX/$FROM ]; then
+        echo "Renaming $FROM -> $TO"
+        mv $FILE_PREFIX/$FROM $FILE_PREFIX/$TO
+    fi
+done
+
+# Overwrite the original ZIP archive
+rm $JAR_PATH
+zip -q -r $JAR_PATH .
+popd
+
+rm -rf $TMP_DIR

--- a/tck-executor/pom.xml
+++ b/tck-executor/pom.xml
@@ -82,10 +82,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/tck-executor/pom.xml
+++ b/tck-executor/pom.xml
@@ -74,20 +74,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
### Motivation
The 6.x.x releases are behind the `master` for key vulnerability fixes and Guava Cache Implementation.
This PR aims to fix that.

### Changes
- Avro Vulnerability fix for `Pulsar-Client-Shaded` jar.
- Guava Cache implementation for handling resource leak caused by `ConcurrentHashMap` of Producers.
- Maven Release Plugin updates to use the new Sonatype release process.