### PR TITLE
[fix] Prevent users from manually setting system message properties in the wrong format

### DIFF
--- a/activemq-filters/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-filters/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -32,6 +32,8 @@ import org.apache.activemq.util.Callback;
 import org.apache.activemq.util.JMSExceptionSupport;
 import org.apache.activemq.util.TypeConversionSupport;
 import org.fusesource.hawtbuf.UTF8Buffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ActiveMQMessage extends Message
     implements org.apache.activemq.Message, ScheduledMessage {
@@ -41,6 +43,7 @@ public class ActiveMQMessage extends Message
 
   private static final Map<String, PropertySetter> JMS_PROPERTY_SETERS =
       new HashMap<String, PropertySetter>();
+  private static final Logger log = LoggerFactory.getLogger(ActiveMQMessage.class);
 
   protected transient Callback acknowledgeCallback;
 
@@ -274,6 +277,11 @@ public class ActiveMQMessage extends Message
   @Override
   public void setJMSExpiration(long expiration) {
     this.setExpiration(expiration);
+      try {
+          this.setLongProperty("JMSExpiration", expiration);
+      } catch (JMSException e) {
+          log.error("Error setting JMSExpiration property", e);
+      }
   }
 
   @Override

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -21,6 +21,7 @@ import com.datastax.oss.pulsar.jms.messages.PulsarObjectMessage;
 import com.datastax.oss.pulsar.jms.messages.PulsarSimpleMessage;
 import com.datastax.oss.pulsar.jms.messages.PulsarStreamMessage;
 import com.datastax.oss.pulsar.jms.messages.PulsarTextMessage;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.jms.CompletionListener;
@@ -554,6 +555,7 @@ public abstract class PulsarMessage implements Message {
   @Override
   public void setJMSExpiration(long expiration) throws JMSException {
     this.jmsExpiration = expiration;
+    setLongPropertyNoCheck(SystemMessageProperty.JMSExpiration.toString(), expiration);
   }
 
   /**
@@ -997,6 +999,10 @@ public abstract class PulsarMessage implements Message {
   @Override
   public void setLongProperty(String name, long value) throws JMSException {
     checkWritableProperty(name);
+    setLongPropertyNoCheck(name, value);
+  }
+
+  protected void setLongPropertyNoCheck(String name, long value) throws JMSException {
     properties.put(name, Long.toString(value));
     properties.put(propertyType(name), "long");
   }
@@ -1045,8 +1051,13 @@ public abstract class PulsarMessage implements Message {
   @Override
   public void setStringProperty(String name, String value) throws JMSException {
     checkWritableProperty(name);
-    properties.put(name, value);
+    setStringPropertyNoCheck(name, value);
     // not type, not needed
+  }
+
+  @VisibleForTesting
+  protected void setStringPropertyNoCheck(String name, String value) throws JMSException {
+    properties.put(name, value);
   }
 
   /**
@@ -1279,7 +1290,7 @@ public abstract class PulsarMessage implements Message {
 
     // we can use JMSXGroupID as key in order to provide
     // a behaviour similar to https://activemq.apache.org/message-groups
-    String JMSXGroupID = properties.get("JMSXGroupID");
+    String JMSXGroupID = properties.get(SystemMessageProperty.JMSXGroupID.toString());
     if (JMSXGroupID != null) {
       message.key(JMSXGroupID);
     }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -114,8 +114,9 @@ public abstract class PulsarMessage implements Message {
   static final Set<String> systemPropertyNames =
       ImmutableSet.copyOf(
           Arrays.stream(SystemMessageProperty.values())
-              // have to allow setting JMSXGroupID externally
+              // have to allow setting JMSXGroupID and JMSXGroupSeq externally
               .filter(x -> x != SystemMessageProperty.JMSXGroupID)
+              .filter(x -> x != SystemMessageProperty.JMSXGroupSeq)
               .map(SystemMessageProperty::toString)
               .collect(Collectors.toSet()));
 

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -114,6 +114,8 @@ public abstract class PulsarMessage implements Message {
   static final Set<String> systemPropertyNames =
       ImmutableSet.copyOf(
           Arrays.stream(SystemMessageProperty.values())
+              // have to allow setting JMSXGroupID externally
+              .filter(x -> x != SystemMessageProperty.JMSXGroupID)
               .map(SystemMessageProperty::toString)
               .collect(Collectors.toSet()));
 

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -1422,9 +1422,15 @@ public abstract class PulsarMessage implements Message {
     assignSystemMessageId(msg.getMessageId());
 
     if (msg.hasProperty(SystemMessageProperty.JMSCorrelationID.toString())) {
-      this.correlationId =
-          Base64.getDecoder()
-              .decode(msg.getProperty(SystemMessageProperty.JMSCorrelationID.toString()));
+      try {
+        this.correlationId =
+            Base64.getDecoder()
+                .decode(msg.getProperty(SystemMessageProperty.JMSCorrelationID.toString()));
+      } catch (IllegalArgumentException iae) {
+        String cId = msg.getProperty(SystemMessageProperty.JMSCorrelationID.toString());
+        log.error("Correlation ID {} is invalid, using raw bytes", cId, iae);
+        this.correlationId = cId.getBytes(StandardCharsets.UTF_8);
+      }
     }
     if (msg.hasProperty(SystemMessageProperty.JMSPriority.toString())) {
       this.jmsPriority = readJMSPriority(msg);

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -21,6 +21,7 @@ import com.datastax.oss.pulsar.jms.messages.PulsarObjectMessage;
 import com.datastax.oss.pulsar.jms.messages.PulsarSimpleMessage;
 import com.datastax.oss.pulsar.jms.messages.PulsarStreamMessage;
 import com.datastax.oss.pulsar.jms.messages.PulsarTextMessage;
+import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.jms.CompletionListener;
 import jakarta.jms.DeliveryMode;
@@ -39,12 +40,14 @@ import java.io.EOFException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -78,6 +81,40 @@ public abstract class PulsarMessage implements Message {
   private Consumer<?> pulsarConsumer;
   private boolean negativeAcked;
   private org.apache.pulsar.client.api.Message<?> receivedPulsarMessage;
+
+  public enum SystemMessageProperty {
+    JMSMessageId("JMSMessageId"),
+    JMSDeliveryTime("JMSDeliveryTime"),
+    JMSXDeliveryCount("JMSXDeliveryCount"),
+    JMSExpiration("JMSExpiration"),
+    JMSXGroupID("JMSXGroupID"),
+    JMSXGroupSeq("JMSXGroupSeq"),
+    JMSPulsarMessageType("JMSPulsarMessageType"),
+    JMSReplyTo("JMSReplyTo"),
+    JMSReplyToType("JMSReplyToType"),
+    JMSType("JMSType"),
+    JMSCorrelationID("JMSCorrelationID"),
+    JMSDeliveryMode("JMSDeliveryMode"),
+    JMSPriority("JMSPriority"),
+    JMSTX("JMSTX");
+
+    public final String label;
+
+    private SystemMessageProperty(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return this.label;
+    }
+  }
+
+  static final Set<String> systemPropertyNames =
+      ImmutableSet.copyOf(
+          Arrays.stream(SystemMessageProperty.values())
+              .map(SystemMessageProperty::toString)
+              .collect(Collectors.toSet()));
 
   /**
    * Gets the message ID.
@@ -1137,6 +1174,14 @@ public abstract class PulsarMessage implements Message {
     if (!writable) {
       throw new MessageNotWriteableException("Not writeable");
     }
+
+    if (systemPropertyNames.contains(name)) {
+      throw new IllegalArgumentException(
+          "System property '"
+              + name
+              + "' either cannot be set externally "
+              + "or has to be set using corresponding setter");
+    }
   }
 
   protected abstract String messageType();
@@ -1185,32 +1230,34 @@ public abstract class PulsarMessage implements Message {
     consumer = null;
     message.properties(properties);
     // useful for deserialization
-    message.property("JMSPulsarMessageType", messageType());
+    message.property(SystemMessageProperty.JMSPulsarMessageType.toString(), messageType());
     if (messageId != null) {
-      message.property("JMSMessageId", messageId);
+      message.property(SystemMessageProperty.JMSMessageId.toString(), messageId);
     }
     if (jmsReplyTo != null) {
       // here we want to keep the original name passed by the user
       // if we have the subscription name in the form Queue:Subscription
       // then here we want to keep the Subscription name
       message.property(
-          "JMSReplyTo",
+          SystemMessageProperty.JMSReplyTo.toString(),
           session.getFactory().applySystemNamespace(((PulsarDestination) jmsReplyTo).topicName));
       if (((PulsarDestination) jmsReplyTo).isTopic()) {
-        message.property("JMSReplyToType", "topic");
+        message.property(SystemMessageProperty.JMSReplyToType.toString(), "topic");
       }
     }
     if (jmsType != null) {
-      message.property("JMSType", jmsType);
+      message.property(SystemMessageProperty.JMSType.toString(), jmsType);
     }
     if (correlationId != null) {
-      message.property("JMSCorrelationID", Base64.getEncoder().encodeToString(correlationId));
+      message.property(
+          SystemMessageProperty.JMSCorrelationID.toString(),
+          Base64.getEncoder().encodeToString(correlationId));
     }
     if (deliveryMode != DeliveryMode.PERSISTENT) {
-      message.property("JMSDeliveryMode", deliveryMode + "");
+      message.property(SystemMessageProperty.JMSDeliveryMode.toString(), deliveryMode + "");
     }
     if (jmsPriority != Message.DEFAULT_PRIORITY) {
-      message.property("JMSPriority", jmsPriority + "");
+      message.property(SystemMessageProperty.JMSPriority.toString(), jmsPriority + "");
     }
 
     this.jmsTimestamp = System.currentTimeMillis();
@@ -1223,11 +1270,11 @@ public abstract class PulsarMessage implements Message {
       this.jmsDeliveryTime = System.currentTimeMillis();
     }
 
-    message.property("JMSDeliveryTime", jmsDeliveryTime + "");
+    message.property(SystemMessageProperty.JMSDeliveryTime.toString(), jmsDeliveryTime + "");
 
     long stickyKey = session.getTransactionStickyKey();
     if (stickyKey > 0) {
-      message.property("JMSTX", Long.toString(stickyKey));
+      message.property(SystemMessageProperty.JMSTX.toString(), Long.toString(stickyKey));
     }
 
     // we can use JMSXGroupID as key in order to provide
@@ -1260,7 +1307,7 @@ public abstract class PulsarMessage implements Message {
     }
     Object value = msg.getValue();
     if (value instanceof byte[] || value == null) {
-      String type = msg.getProperty("JMSPulsarMessageType");
+      String type = msg.getProperty(SystemMessageProperty.JMSPulsarMessageType.toString());
       if (type == null) {
         type = "bytes"; // non JMS clients
       }
@@ -1354,9 +1401,9 @@ public abstract class PulsarMessage implements Message {
     if (consumer != null) {
       this.destination = consumer.getDestination();
     }
-    String jmsReplyTo = msg.getProperty("JMSReplyTo");
+    String jmsReplyTo = msg.getProperty(SystemMessageProperty.JMSReplyTo.toString());
     if (jmsReplyTo != null) {
-      String jmsReplyToType = msg.getProperty("JMSReplyToType") + "";
+      String jmsReplyToType = msg.getProperty(SystemMessageProperty.JMSReplyToType.toString()) + "";
       switch (jmsReplyToType) {
         case "topic":
           this.jmsReplyTo = new PulsarTopic(jmsReplyTo);
@@ -1365,31 +1412,35 @@ public abstract class PulsarMessage implements Message {
           this.jmsReplyTo = new PulsarQueue(jmsReplyTo);
       }
     }
-    if (msg.hasProperty("JMSType")) {
-      this.jmsType = msg.getProperty("JMSType");
+    if (msg.hasProperty(SystemMessageProperty.JMSType.toString())) {
+      this.jmsType = msg.getProperty(SystemMessageProperty.JMSType.toString());
     }
 
-    if (msg.hasProperty("JMSMessageId")) {
-      this.messageId = msg.getProperty("JMSMessageId");
+    if (msg.hasProperty(SystemMessageProperty.JMSMessageId.toString())) {
+      this.messageId = msg.getProperty(SystemMessageProperty.JMSMessageId.toString());
     }
     assignSystemMessageId(msg.getMessageId());
 
-    if (msg.hasProperty("JMSCorrelationID")) {
-      this.correlationId = Base64.getDecoder().decode(msg.getProperty("JMSCorrelationID"));
+    if (msg.hasProperty(SystemMessageProperty.JMSCorrelationID.toString())) {
+      this.correlationId =
+          Base64.getDecoder()
+              .decode(msg.getProperty(SystemMessageProperty.JMSCorrelationID.toString()));
     }
-    if (msg.hasProperty("JMSPriority")) {
+    if (msg.hasProperty(SystemMessageProperty.JMSPriority.toString())) {
       this.jmsPriority = readJMSPriority(msg);
     }
-    if (msg.hasProperty("JMSDeliveryMode")) {
+    if (msg.hasProperty(SystemMessageProperty.JMSDeliveryMode.toString())) {
       try {
-        this.deliveryMode = Integer.parseInt(msg.getProperty("JMSDeliveryMode"));
+        this.deliveryMode =
+            Integer.parseInt(msg.getProperty(SystemMessageProperty.JMSDeliveryMode.toString()));
       } catch (NumberFormatException err) {
         // cannot decode deliveryMode, not a big deal as it is not supported in Pulsar
       }
     }
-    if (msg.hasProperty("JMSExpiration")) {
+    if (msg.hasProperty(SystemMessageProperty.JMSExpiration.toString())) {
       try {
-        this.jmsExpiration = Long.parseLong(msg.getProperty("JMSExpiration"));
+        this.jmsExpiration =
+            Long.parseLong(msg.getProperty(SystemMessageProperty.JMSExpiration.toString()));
       } catch (NumberFormatException err) {
         // cannot decode JMSExpiration
       }
@@ -1398,22 +1449,24 @@ public abstract class PulsarMessage implements Message {
     this.jmsTimestamp = msg.getEventTime();
 
     this.jmsDeliveryTime = jmsTimestamp;
-    if (msg.hasProperty("JMSDeliveryTime")) {
+    if (msg.hasProperty(SystemMessageProperty.JMSDeliveryTime.toString())) {
       try {
-        this.jmsDeliveryTime = Long.parseLong(msg.getProperty("JMSDeliveryTime"));
+        this.jmsDeliveryTime =
+            Long.parseLong(msg.getProperty(SystemMessageProperty.JMSDeliveryTime.toString()));
       } catch (NumberFormatException err) {
         // cannot decode JMSDeliveryTime
       }
     }
 
-    this.properties.put("JMSXDeliveryCount", (msg.getRedeliveryCount() + 1) + "");
+    this.properties.put(
+        SystemMessageProperty.JMSXDeliveryCount.toString(), (msg.getRedeliveryCount() + 1) + "");
     if (msg.getKey() != null) {
-      this.properties.put("JMSXGroupID", msg.getKey());
+      this.properties.put(SystemMessageProperty.JMSXGroupID.toString(), msg.getKey());
     } else {
-      this.properties.put("JMSXGroupID", "");
+      this.properties.put(SystemMessageProperty.JMSXGroupID.toString(), "");
     }
-    if (!properties.containsKey("JMSXGroupSeq")) {
-      this.properties.put("JMSXGroupSeq", msg.getSequenceId() + "");
+    if (!properties.containsKey(SystemMessageProperty.JMSXGroupSeq.toString())) {
+      this.properties.put(SystemMessageProperty.JMSXGroupSeq.toString(), msg.getSequenceId() + "");
     }
 
     this.jmsRedelivered = msg.getRedeliveryCount() > 0;
@@ -1479,9 +1532,9 @@ public abstract class PulsarMessage implements Message {
   }
 
   public static int readJMSPriority(org.apache.pulsar.client.api.Message<?> msg) {
-    if (msg.hasProperty("JMSPriority")) {
+    if (msg.hasProperty(SystemMessageProperty.JMSPriority.toString())) {
       try {
-        int value = Integer.parseInt(msg.getProperty("JMSPriority"));
+        int value = Integer.parseInt(msg.getProperty(SystemMessageProperty.JMSPriority.toString()));
         if (value < 0 || value >= 10) { // impossible values according to JMS Specs
           return PulsarMessage.DEFAULT_PRIORITY;
         }

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -1194,7 +1194,6 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
   private void applyTimeToLive(Message message, long timeToLive) throws JMSException {
     if (timeToLive > 0) {
       long time = System.currentTimeMillis() + timeToLive;
-      message.setLongProperty("JMSExpiration", System.currentTimeMillis() + timeToLive);
       message.setJMSExpiration(time);
     }
   }

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -74,8 +73,7 @@ public class PulsarInteropTest {
 
               try (MessageProducer producer = session.createProducer(destination)) {
                 TextMessage textMsg = session.createTextMessage("foo");
-                MethodUtils.invokeMethod(
-                    textMsg, true, "setStringPropertyNoCheck", "JMSXGroupID", "bar");
+                textMsg.setStringProperty("JMSXGroupID", "bar");
                 producer.send(textMsg);
 
                 Message<String> receivedMessage = consumer.receive();

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/PulsarInteropTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -71,9 +72,10 @@ public class PulsarInteropTest {
                     .topic(topic)
                     .subscribe()) {
 
-              try (MessageProducer producer = session.createProducer(destination); ) {
+              try (MessageProducer producer = session.createProducer(destination)) {
                 TextMessage textMsg = session.createTextMessage("foo");
-                textMsg.setStringProperty("JMSXGroupID", "bar");
+                MethodUtils.invokeMethod(
+                    textMsg, true, "setStringPropertyNoCheck", "JMSXGroupID", "bar");
                 producer.send(textMsg);
 
                 Message<String> receivedMessage = consumer.receive();

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
@@ -19,9 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.datastax.oss.pulsar.jms.messages.PulsarSimpleMessage;
 import com.datastax.oss.pulsar.jms.utils.PulsarContainerExtension;
 import jakarta.jms.BytesMessage;
 import jakarta.jms.CompletionListener;
@@ -62,6 +64,32 @@ public class SimpleTest {
 
   @RegisterExtension
   static PulsarContainerExtension pulsarContainer = new PulsarContainerExtension();
+
+  @Test
+  public void testSystemPropertySetters() throws Exception {
+    Message simpleMessage = new PulsarSimpleMessage();
+    for (PulsarMessage.SystemMessageProperty prop : PulsarMessage.SystemMessageProperty.values()) {
+      String name = prop.toString();
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setByteProperty(name, (byte) 1));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setLongProperty(name, 123232323233L));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setIntProperty(name, 1232323));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setStringProperty(name, "ttt"));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setBooleanProperty(name, true));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setFloatProperty(name, 1.3f));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setDoubleProperty(name, 1.9d));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setShortProperty(name, (short) 89));
+      assertThrows(
+          IllegalArgumentException.class, () -> simpleMessage.setObjectProperty(name, 1.3d));
+    }
+  }
 
   @Test
   public void sendMessageTest() throws Exception {

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
@@ -72,7 +72,7 @@ public class SimpleTest {
       if (prop == PulsarMessage.SystemMessageProperty.JMSXGroupID) {
         simpleMessage.setStringProperty("JMSXGroupID", "groupId");
       } else if (prop == PulsarMessage.SystemMessageProperty.JMSXGroupSeq) {
-        simpleMessage.setIntProperty("JMSXGroupID", 1);
+        simpleMessage.setIntProperty("JMSXGroupSeq", 1);
       } else {
         String name = prop.toString();
         assertThrows(

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
@@ -71,6 +71,8 @@ public class SimpleTest {
     for (PulsarMessage.SystemMessageProperty prop : PulsarMessage.SystemMessageProperty.values()) {
       if (prop == PulsarMessage.SystemMessageProperty.JMSXGroupID) {
         simpleMessage.setStringProperty("JMSXGroupID", "groupId");
+      } else if (prop == PulsarMessage.SystemMessageProperty.JMSXGroupSeq) {
+        simpleMessage.setIntProperty("JMSXGroupID", 1);
       } else {
         String name = prop.toString();
         assertThrows(

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/SimpleTest.java
@@ -69,25 +69,29 @@ public class SimpleTest {
   public void testSystemPropertySetters() throws Exception {
     Message simpleMessage = new PulsarSimpleMessage();
     for (PulsarMessage.SystemMessageProperty prop : PulsarMessage.SystemMessageProperty.values()) {
-      String name = prop.toString();
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setByteProperty(name, (byte) 1));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setLongProperty(name, 123232323233L));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setIntProperty(name, 1232323));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setStringProperty(name, "ttt"));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setBooleanProperty(name, true));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setFloatProperty(name, 1.3f));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setDoubleProperty(name, 1.9d));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setShortProperty(name, (short) 89));
-      assertThrows(
-          IllegalArgumentException.class, () -> simpleMessage.setObjectProperty(name, 1.3d));
+      if (prop == PulsarMessage.SystemMessageProperty.JMSXGroupID) {
+        simpleMessage.setStringProperty("JMSXGroupID", "groupId");
+      } else {
+        String name = prop.toString();
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setByteProperty(name, (byte) 1));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setLongProperty(name, 123232323233L));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setIntProperty(name, 1232323));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setStringProperty(name, "ttt"));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setBooleanProperty(name, true));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setFloatProperty(name, 1.3f));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setDoubleProperty(name, 1.9d));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setShortProperty(name, (short) 89));
+        assertThrows(
+                IllegalArgumentException.class, () -> simpleMessage.setObjectProperty(name, 1.3d));
+      }
     }
   }
 

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TopicTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TopicTest.java
@@ -47,7 +47,6 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
@@ -454,8 +453,7 @@ public class TopicTest {
             try (MessageProducer producer = session.createProducer(destination); ) {
               for (int i = 0; i < 100; i++) {
                 TextMessage textMessage = session.createTextMessage("foo-" + i);
-                MethodUtils.invokeMethod(
-                    textMessage, true, "setStringPropertyNoCheck", "JMSXGroupID", "key" + (i % 10));
+                textMessage.setStringProperty("JMSXGroupID", "key" + (i % 10));
                 textMessage.setIntProperty("ordinal", i);
                 producer.send(
                     textMessage,

--- a/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TopicTest.java
+++ b/pulsar-jms/src/test/java/com/datastax/oss/pulsar/jms/TopicTest.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
@@ -453,7 +454,8 @@ public class TopicTest {
             try (MessageProducer producer = session.createProducer(destination); ) {
               for (int i = 0; i < 100; i++) {
                 TextMessage textMessage = session.createTextMessage("foo-" + i);
-                textMessage.setStringProperty("JMSXGroupID", "key" + (i % 10));
+                MethodUtils.invokeMethod(
+                    textMessage, true, "setStringPropertyNoCheck", "JMSXGroupID", "key" + (i % 10));
                 textMessage.setIntProperty("ordinal", i);
                 producer.send(
                     textMessage,


### PR DESCRIPTION
Context: https://github.com/datastax/pulsar-jms/pull/177#pullrequestreview-2822638111

This does two things:
1. prevents users from manually setting invalid correlation ID via variations of setProperty() calls
2. doesn't block message processing as outlined at https://github.com/datastax/pulsar-jms/pull/177