### PR TITLE
Update pulsar to 3.2.3 & excluding unwanted dependencies to fix vulnerabilities

### DIFF
--- a/examples/payara-micro/pom.xml
+++ b/examples/payara-micro/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>payara-example</artifactId>
   <packaging>ejb</packaging>
-  <name>Payara Micro® JMS Pulsar Example</name>
+  <name>Payara Micro JMS Pulsar Example</name>
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>pulsar-jms-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,14 @@
     <maven.compiler.release>11</maven.compiler.release>
     <jms.version>3.0.0</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
-    <pulsar.version>3.2.2</pulsar.version>
+    <pulsar.version>3.2.3</pulsar.version>
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
     <aircompressor.version>0.27</aircompressor.version>
     <protobuf.version>3.25.5</protobuf.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
     <activemq.version>6.0.0</activemq.version>
+    <netty.version>4.1.118.Final</netty.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
     <slf4j.version>1.7.36</slf4j.version>
@@ -90,6 +91,21 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
@@ -193,6 +209,10 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-protobuf</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -227,6 +247,10 @@
           <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
     <activemq.version>6.0.0</activemq.version>
     <netty.version>4.1.118.Final</netty.version>
+    <commons-lang.version>2.6</commons-lang.version>
+    <commons-logging.version>1.1.1</commons-logging.version>
     <hawtbuf.version>1.11</hawtbuf.version>
     <curator.version>5.1.0</curator.version>
     <slf4j.version>1.7.36</slf4j.version>
@@ -324,6 +326,19 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+<!-- commons-lang & commons-logging were added here as we are excluding commons-configuration to fix vulnerabilities which has these two as transitive dependencies. -->
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${commons-logging.version}</version>
+    </dependency>
+  </dependencies>
   <build>
     <pluginManagement>
       <plugins>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -159,7 +159,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
         <configuration>
           <artifactSet>
             <includes>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -159,6 +159,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
         <configuration>
           <artifactSet>
             <includes>


### PR DESCRIPTION
* Bump pulsar version to 3.2.3 to fix vulnerabilities from bouncy castle (Ref [PR](https://github.com/apache/pulsar/pull/22509) for bc upgrade)
* Exclude unused dep commons-configuration to fix vulnerabilities 
* Bump netty version using dependency management to fix vulnerabilities

Jira Link: https://datastax.jira.com/browse/STREAM-626