### PR TITLE
Update pulsar to 3.2.3 & excluding unwanted dependencies to fix vulnerabilities in 6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,14 @@
     <maven.compiler.release>8</maven.compiler.release>
     <jms.version>2.0.3</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
-    <pulsar.version>3.2.2</pulsar.version>
+    <pulsar.version>3.2.3</pulsar.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
     <activemq.version>5.16.7</activemq.version>
+    <netty.version>4.1.118.Final</netty.version>
+    <commons-lang.version>2.6</commons-lang.version>
+    <commons-logging.version>1.1.1</commons-logging.version>
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
     <aircompressor.version>0.27</aircompressor.version>
     <protobuf.version>3.25.5</protobuf.version>
@@ -90,6 +93,21 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
@@ -193,6 +211,10 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-protobuf</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -227,6 +249,10 @@
           <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -311,6 +337,19 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+    <!-- commons-lang & commons-logging were added here as we are excluding commons-configuration to fix vulnerabilities which has these two as transitive dependencies. -->
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${commons-logging.version}</version>
+    </dependency>
+  </dependencies>
   <build>
     <pluginManagement>
       <plugins>

--- a/pulsar-jms-all/pom.xml
+++ b/pulsar-jms-all/pom.xml
@@ -163,6 +163,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
         <configuration>
           <artifactSet>
             <includes>


### PR DESCRIPTION
* Bump pulsar version to 3.2.3 to fix vulnerabilities from bouncy castle (Ref [PR](https://github.com/apache/pulsar/pull/22509) for bc upgrade)
* Exclude unused dep commons-configuration to fix vulnerabilities 
* Bump netty version using dependency management to fix vulnerabilities
* Exclude commons-configuration as it is not being used anywhere for pulsar-jms.
  * It is being used in pulsar-broker but it is in provided scope. It is not being used in pulsar-client-original or it's transitive dependencies.

Jira Link: https://datastax.jira.com/browse/STREAM-626