### PR TITLE
Update activemq-client from 5.16.7 to 5.16.8 to fix CVE-2025-27533

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
-    <activemq.version>5.16.7</activemq.version>
+    <activemq.version>5.16.8</activemq.version>
     <netty.version>4.1.118.Final</netty.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.1.1</commons-logging.version>


### PR DESCRIPTION
* Update activemq-client from 5.16.7 to 5.16.8 to fix CVE-2025-27533
Jira Link: [STREAM-652](https://datastax.jira.com/browse/STREAM-652)