### PR TITLE
Move dependencies to dependency section from management section & bump versions to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,9 @@
     <jms.version>2.0.3</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
     <pulsar.version>3.2.3</pulsar.version>
-    <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
-    <activemq.version>5.16.7</activemq.version>
+    <activemq.version>5.16.8</activemq.version>
     <netty.version>4.1.118.Final</netty.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.1.1</commons-logging.version>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -47,16 +47,6 @@
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client-original</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.avro</groupId>
-          <artifactId>avro</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.avro</groupId>
-          <artifactId>avro-protobuf</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
@@ -105,6 +95,34 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-protobuf</artifactId>
       <version>1.11.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.asynchttpclient</groupId>
+      <artifactId>async-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
* Update activemq-client from 5.16.7 to 5.16.8 to fix CVE-2025-27533
* Fix for commons configration exclusion in parent that was being overriden by child exclusion
* Add netty to dependency section to fix vulnerability.
* Add snakeyaml to dependency section to fix vulnerability.
* Add protobuf,asynchttpclient,aircompressor dependencies in pulsar-jms module to make dependency tree use latest versions.
Jira Link: [STREAM-652](https://datastax.jira.com/browse/STREAM-652)

[STREAM-652]: https://datastax.jira.com/browse/STREAM-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ