### PR TITLE
  Move dependencies to dependency section from management section & bump versions to fix vulnerabilities for 7.x

### DIFF
--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -54,16 +54,6 @@
     <dependency>
       <groupId>${pulsar.groupId}</groupId>
       <artifactId>pulsar-client-original</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.avro</groupId>
-          <artifactId>avro</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.avro</groupId>
-          <artifactId>avro-protobuf</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
@@ -74,6 +64,34 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-protobuf</artifactId>
       <version>1.11.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.asynchttpclient</groupId>
+      <artifactId>async-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
     </dependency>
     <dependency>
       <groupId>${pulsar.groupId}</groupId>


### PR DESCRIPTION
* Update activemq-client from 5.16.7 to 5.16.8 to fix CVE-2025-27533
* Fix for commons configration exclusion in parent that was being overriden by child exclusion
* Add netty to dependency section to fix vulnerability.
* Add snakeyaml to dependency section to fix vulnerability.
* Add protobuf,asynchttpclient,aircompressor dependencies in pulsar-jms module to make dependency tree use latest versions.
Jira Link: [STREAM-652](https://datastax.jira.com/browse/STREAM-652)

[STREAM-652]: https://datastax.jira.com/browse/STREAM-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ