### PR TITLE
Bump netty, asynchttpclient and commons-configuration dependencies to remediate CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,13 @@
     <jms.version>3.0.0</jms.version>
     <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
     <pulsar.version>4.0.7</pulsar.version>
-    <asynchttpclient.version>2.14.5</asynchttpclient.version>
+    <asynchttpclient.version>2.15.0</asynchttpclient.version>
     <aircompressor.version>2.0.3</aircompressor.version>
     <protobuf.version>3.25.5</protobuf.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
     <activemq.version>6.0.0</activemq.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-logging.version>1.1.1</commons-logging.version>
@@ -77,6 +77,7 @@
     <bouncycastle.version>1.84</bouncycastle.version>
     <gson.version>2.8.9</gson.version>
     <commons-compress.version>1.27.1</commons-compress.version>
+    <commons-configuration.version>2.15.0</commons-configuration.version>
     <awaitility.version>4.2.0</awaitility.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <snakeyaml.version>2.0</snakeyaml.version>
@@ -107,8 +108,28 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
         <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>${commons-configuration.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Bump netty, asynchttpclient and commons-configuration dependencies to remediate CVEs from the snyk scan report https://app.snyk.io/org/streamingecr/project/e31c77a6-3c3f-4910-b818-90e52a7836dd